### PR TITLE
Implement responsive meal planner interface

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,34 +1,194 @@
-.App {
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.page__title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--color-text-strong);
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.grid--responsive {
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+}
+
+.stack {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.section-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.chip-list__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4xs);
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 999px;
+  padding: var(--space-4xs) var(--space-2xs) var(--space-4xs) var(--space-4xs);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.chip-list__item--static {
+  padding-right: var(--space-xs);
+}
+
+.chip-list__remove {
+  border: none;
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 999px;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.chip-list__remove:hover {
+  background: rgba(248, 113, 113, 0.25);
+  color: rgb(185, 28, 28);
+}
+
+.card-action-buttons {
+  display: flex;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.muted {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.multiline {
+  white-space: pre-line;
+  margin: 0;
+}
+
+.meal-group-card {
+  position: relative;
+}
+
+.meal-group-card__accent {
+  width: 60px;
+  height: 6px;
+  border-radius: 999px;
+  margin-bottom: var(--space-sm);
+}
+
+.dish-card__image {
+  width: 100%;
+  border-radius: var(--radius-xl);
+  max-height: 200px;
+  object-fit: cover;
+}
+
+.dish-card__info {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.dish-card__ingredients {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.ingredient-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.ingredient-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.ingredient-list__actions {
+  display: flex;
+  gap: var(--space-2xs);
+}
+
+.product-card__dishes {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.loading-state {
+  display: grid;
+  gap: var(--space-sm);
+  justify-items: center;
+  padding: var(--space-xl) 0;
+  color: var(--color-muted);
+}
+
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 126, 95, 0.3);
+  border-top-color: var(--color-primary);
+  animation: spinner 1s linear infinite;
+}
+
+.footer-note {
   text-align: center;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  margin: var(--space-xs) 0 0;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.alert__action {
+  margin-left: var(--space-sm);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
+@media (min-width: 768px) {
+  .page__title {
+    font-size: 1.6rem;
   }
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
+@keyframes spinner {
   from {
     transform: rotate(0deg);
   }
@@ -36,3 +196,4 @@
     transform: rotate(360deg);
   }
 }
+

--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,113 @@
-import logo from './logo.svg';
+import { useMemo, useState } from 'react';
 import './App.css';
+import { AppLayout } from './components/layout/AppLayout';
+import { usePlannerData } from './hooks/usePlannerData';
+import { MealPlannerPage } from './pages/MealPlannerPage';
+import { DishesPage } from './pages/DishesPage';
+import { ProductsPage } from './pages/ProductsPage';
+import { Alert } from './components/common/Alert';
+import { Button } from './components/common/Button';
+
+const VIEW_CONFIG = {
+  planner: {
+    title: 'Домашний план питания',
+    subtitle: 'MealMate',
+  },
+  dishes: {
+    title: 'Коллекция блюд',
+    subtitle: 'MealMate',
+  },
+  products: {
+    title: 'Продукты и холодильник',
+    subtitle: 'MealMate',
+  },
+};
+
+const NAV_ITEMS = [
+  { id: 'planner', label: 'План', icon: '🗓️' },
+  { id: 'dishes', label: 'Блюда', icon: '🍽️' },
+  { id: 'products', label: 'Продукты', icon: '🧺' },
+];
 
 function App() {
+  const [view, setView] = useState('planner');
+  const planner = usePlannerData();
+
+  const { title, subtitle } = VIEW_CONFIG[view] ?? VIEW_CONFIG.planner;
+
+  const content = useMemo(() => {
+    if (planner.loading) {
+      return (
+        <div className="loading-state">
+          <div className="loading-spinner" aria-hidden />
+          <p>Загружаем ваши блюда и продукты…</p>
+        </div>
+      );
+    }
+
+    switch (view) {
+      case 'dishes':
+        return (
+          <DishesPage
+            dishes={planner.dishes}
+            products={planner.products}
+            createDish={planner.createDish}
+            updateDish={planner.updateDish}
+            deleteDish={planner.deleteDish}
+            createDishProduct={planner.createDishProduct}
+            updateDishProduct={planner.updateDishProduct}
+            deleteDishProduct={planner.deleteDishProduct}
+            isMutating={planner.isMutating}
+          />
+        );
+      case 'products':
+        return (
+          <ProductsPage
+            products={planner.products}
+            createProduct={planner.createProduct}
+            updateProduct={planner.updateProduct}
+            deleteProduct={planner.deleteProduct}
+            isMutating={planner.isMutating}
+          />
+        );
+      case 'planner':
+      default:
+        return (
+          <MealPlannerPage
+            mealGroups={planner.mealGroups}
+            dishes={planner.dishes}
+            createMealGroup={planner.createMealGroup}
+            updateMealGroup={planner.updateMealGroup}
+            deleteMealGroup={planner.deleteMealGroup}
+            createMealGroupDish={planner.createMealGroupDish}
+            deleteMealGroupDish={planner.deleteMealGroupDish}
+            isMutating={planner.isMutating}
+          />
+        );
+    }
+  }, [planner, view]);
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <AppLayout
+      activeView={view}
+      onChangeView={setView}
+      title={title}
+      subtitle={subtitle}
+      navigationItems={NAV_ITEMS}
+      footer={<p className="footer-note">MealMate © {new Date().getFullYear()}</p>}
+    >
+      {planner.error && (
+        <Alert tone="error" title="Что-то пошло не так" onClose={planner.clearError}>
+          {planner.error}
+          <Button variant="ghost" onClick={planner.refresh} className="alert__action">
+            Повторить
+          </Button>
+        </Alert>
+      )}
+      {content}
+    </AppLayout>
   );
 }
 
 export default App;
+

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,24 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([]),
+      headers: {
+        get: () => 'application/json',
+      },
+    }),
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('renders planner title', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = await screen.findByText(/домашний план питания/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/api/apiConfig.js
+++ b/src/api/apiConfig.js
@@ -1,0 +1,20 @@
+const DEFAULT_BASE_URL = 'http://localhost:8080';
+
+export const apiConfig = {
+  baseUrl: process.env.REACT_APP_API_BASE_URL || DEFAULT_BASE_URL,
+  endpoints: {
+    dishes: '/api/dishes',
+    products: '/api/products',
+    mealGroups: '/api/meal-groups',
+    dishProducts: '/api/dish-products',
+    mealGroupDishes: '/api/meal-group-dishes',
+  },
+};
+
+export const buildApiUrl = (path = '') => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${apiConfig.baseUrl}${normalizedPath}`;
+};
+
+export const getEndpoint = (key) => apiConfig.endpoints[key];
+

--- a/src/api/dishProducts.js
+++ b/src/api/dishProducts.js
@@ -1,0 +1,19 @@
+import { apiRequest } from './httpClient';
+import { getEndpoint } from './apiConfig';
+
+const endpoint = getEndpoint('dishProducts');
+
+export const fetchDishProducts = () => apiRequest(endpoint);
+
+export const fetchDishProduct = (dishId, productId) =>
+  apiRequest(`${endpoint}/${dishId}/${productId}`);
+
+export const createDishProduct = (payload) =>
+  apiRequest(endpoint, { method: 'POST', body: payload });
+
+export const updateDishProduct = (dishId, productId, payload) =>
+  apiRequest(`${endpoint}/${dishId}/${productId}`, { method: 'PUT', body: payload });
+
+export const deleteDishProduct = (dishId, productId) =>
+  apiRequest(`${endpoint}/${dishId}/${productId}`, { method: 'DELETE' });
+

--- a/src/api/dishes.js
+++ b/src/api/dishes.js
@@ -1,0 +1,18 @@
+import { apiRequest } from './httpClient';
+import { getEndpoint } from './apiConfig';
+
+const endpoint = getEndpoint('dishes');
+
+export const fetchDishes = () => apiRequest(endpoint);
+
+export const fetchDish = (id) => apiRequest(`${endpoint}/${id}`);
+
+export const createDish = (payload) =>
+  apiRequest(endpoint, { method: 'POST', body: payload });
+
+export const updateDish = (id, payload) =>
+  apiRequest(`${endpoint}/${id}`, { method: 'PUT', body: payload });
+
+export const deleteDish = (id) =>
+  apiRequest(`${endpoint}/${id}`, { method: 'DELETE' });
+

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -1,0 +1,45 @@
+import { buildApiUrl } from './apiConfig';
+
+const defaultHeaders = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
+
+const parseResponse = async (response) => {
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+};
+
+export async function apiRequest(path, { method = 'GET', body, headers, ...rest } = {}) {
+  const url = buildApiUrl(path);
+  const config = {
+    method,
+    headers: { ...defaultHeaders, ...headers },
+    ...rest,
+  };
+
+  if (body !== undefined) {
+    config.body = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+
+  const response = await fetch(url, config);
+  const payload = await parseResponse(response);
+
+  if (!response.ok) {
+    const error = new Error('API request failed');
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+}
+
+export const buildResourceUrl = (endpoint, suffix = '') => {
+  const path = `${endpoint}${suffix}`;
+  return buildApiUrl(path);
+};
+

--- a/src/api/mealGroupDishes.js
+++ b/src/api/mealGroupDishes.js
@@ -1,0 +1,19 @@
+import { apiRequest } from './httpClient';
+import { getEndpoint } from './apiConfig';
+
+const endpoint = getEndpoint('mealGroupDishes');
+
+export const fetchMealGroupDishes = () => apiRequest(endpoint);
+
+export const fetchMealGroupDish = (mealGroupId, dishId) =>
+  apiRequest(`${endpoint}/${mealGroupId}/${dishId}`);
+
+export const createMealGroupDish = (payload) =>
+  apiRequest(endpoint, { method: 'POST', body: payload });
+
+export const updateMealGroupDish = (mealGroupId, dishId, payload) =>
+  apiRequest(`${endpoint}/${mealGroupId}/${dishId}`, { method: 'PUT', body: payload });
+
+export const deleteMealGroupDish = (mealGroupId, dishId) =>
+  apiRequest(`${endpoint}/${mealGroupId}/${dishId}`, { method: 'DELETE' });
+

--- a/src/api/mealGroups.js
+++ b/src/api/mealGroups.js
@@ -1,0 +1,18 @@
+import { apiRequest } from './httpClient';
+import { getEndpoint } from './apiConfig';
+
+const endpoint = getEndpoint('mealGroups');
+
+export const fetchMealGroups = () => apiRequest(endpoint);
+
+export const fetchMealGroup = (id) => apiRequest(`${endpoint}/${id}`);
+
+export const createMealGroup = (payload) =>
+  apiRequest(endpoint, { method: 'POST', body: payload });
+
+export const updateMealGroup = (id, payload) =>
+  apiRequest(`${endpoint}/${id}`, { method: 'PUT', body: payload });
+
+export const deleteMealGroup = (id) =>
+  apiRequest(`${endpoint}/${id}`, { method: 'DELETE' });
+

--- a/src/api/products.js
+++ b/src/api/products.js
@@ -1,0 +1,18 @@
+import { apiRequest } from './httpClient';
+import { getEndpoint } from './apiConfig';
+
+const endpoint = getEndpoint('products');
+
+export const fetchProducts = () => apiRequest(endpoint);
+
+export const fetchProduct = (id) => apiRequest(`${endpoint}/${id}`);
+
+export const createProduct = (payload) =>
+  apiRequest(endpoint, { method: 'POST', body: payload });
+
+export const updateProduct = (id, payload) =>
+  apiRequest(`${endpoint}/${id}`, { method: 'PUT', body: payload });
+
+export const deleteProduct = (id) =>
+  apiRequest(`${endpoint}/${id}`, { method: 'DELETE' });
+

--- a/src/components/common/Alert.css
+++ b/src/components/common/Alert.css
@@ -1,0 +1,35 @@
+.alert {
+  border-radius: var(--radius-xl);
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.alert--info {
+  background: rgba(59, 130, 246, 0.12);
+  color: rgb(29, 78, 216);
+}
+
+.alert--error {
+  background: rgba(248, 113, 113, 0.14);
+  color: rgb(185, 28, 28);
+}
+
+.alert__title {
+  font-weight: 700;
+}
+
+.alert__message {
+  margin: var(--space-4xs) 0 0;
+}
+
+.alert__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+

--- a/src/components/common/Alert.js
+++ b/src/components/common/Alert.js
@@ -1,0 +1,16 @@
+import './Alert.css';
+
+export const Alert = ({ tone = 'info', title, children, onClose }) => (
+  <div className={`alert alert--${tone}`} role="alert">
+    <div className="alert__content">
+      {title && <strong className="alert__title">{title}</strong>}
+      {children && <p className="alert__message">{children}</p>}
+    </div>
+    {onClose && (
+      <button type="button" className="alert__close" onClick={onClose} aria-label="Закрыть оповещение">
+        ×
+      </button>
+    )}
+  </div>
+);
+

--- a/src/components/common/Button.css
+++ b/src/components/common/Button.css
@@ -1,0 +1,54 @@
+.btn {
+  border: none;
+  border-radius: var(--radius-xl);
+  padding: var(--space-sm) var(--space-lg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  transition: transform 120ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: white;
+  box-shadow: 0 10px 24px rgba(255, 126, 95, 0.3);
+}
+
+.btn--primary:hover:not(:disabled),
+.btn--primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(255, 126, 95, 0.32);
+}
+
+.btn--ghost {
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--color-primary-strong);
+  box-shadow: inset 0 0 0 1px rgba(255, 126, 95, 0.3);
+}
+
+.btn--ghost:hover:not(:disabled),
+.btn--ghost:focus-visible {
+  background: rgba(255, 126, 95, 0.15);
+}
+
+.btn--danger {
+  background: rgba(248, 113, 113, 0.12);
+  color: rgb(185, 28, 28);
+  box-shadow: inset 0 0 0 1px rgba(185, 28, 28, 0.2);
+}
+
+.btn--danger:hover:not(:disabled),
+.btn--danger:focus-visible {
+  background: rgba(248, 113, 113, 0.2);
+}
+

--- a/src/components/common/Button.js
+++ b/src/components/common/Button.js
@@ -1,0 +1,8 @@
+import './Button.css';
+
+export const Button = ({ variant = 'primary', children, className = '', ...props }) => (
+  <button type="button" className={`btn btn--${variant} ${className}`.trim()} {...props}>
+    {children}
+  </button>
+);
+

--- a/src/components/common/Card.css
+++ b/src/components/common/Card.css
@@ -1,0 +1,55 @@
+.card {
+  background: white;
+  border-radius: var(--radius-2xl);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.card--muted {
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+}
+
+.card__subtitle {
+  margin: var(--space-3xs) 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.card__header-actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.card__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: auto;
+}
+

--- a/src/components/common/Card.js
+++ b/src/components/common/Card.js
@@ -1,0 +1,24 @@
+import './Card.css';
+
+export const Card = ({ tone = 'default', children, className = '', ...props }) => (
+  <section className={`card card--${tone} ${className}`.trim()} {...props}>
+    {children}
+  </section>
+);
+
+export const CardHeader = ({ title, subtitle, endSlot }) => (
+  <header className="card__header">
+    <div>
+      <h2 className="card__title">{title}</h2>
+      {subtitle && <p className="card__subtitle">{subtitle}</p>}
+    </div>
+    {endSlot && <div className="card__header-actions">{endSlot}</div>}
+  </header>
+);
+
+export const CardContent = ({ children }) => <div className="card__content">{children}</div>;
+
+export const CardFooter = ({ children }) => (
+  <footer className="card__footer">{children}</footer>
+);
+

--- a/src/components/common/EmptyState.css
+++ b/src/components/common/EmptyState.css
@@ -1,0 +1,28 @@
+.empty-state {
+  padding: var(--space-xl);
+  border-radius: var(--radius-2xl);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  text-align: center;
+  display: grid;
+  gap: var(--space-sm);
+  justify-items: center;
+}
+
+.empty-state__icon {
+  font-size: 2.5rem;
+}
+
+.empty-state__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+}
+
+.empty-state__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+

--- a/src/components/common/EmptyState.js
+++ b/src/components/common/EmptyState.js
@@ -1,0 +1,13 @@
+import './EmptyState.css';
+
+export const EmptyState = ({ title, description, action }) => (
+  <div className="empty-state">
+    <div className="empty-state__icon" aria-hidden>
+      🍽️
+    </div>
+    <h3 className="empty-state__title">{title}</h3>
+    {description && <p className="empty-state__description">{description}</p>}
+    {action && <div className="empty-state__action">{action}</div>}
+  </div>
+);
+

--- a/src/components/common/Modal.css
+++ b/src/components/common/Modal.css
@@ -1,0 +1,64 @@
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(6px);
+}
+
+.modal__dialog {
+  position: relative;
+  width: min(640px, calc(100vw - 2 * var(--space-md)));
+  max-height: calc(100vh - 2 * var(--space-xl));
+  border-radius: var(--radius-2xl);
+  background: white;
+  box-shadow: 0 40px 60px rgba(15, 23, 42, 0.25);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__header {
+  padding: var(--space-lg) var(--space-xl) var(--space-sm);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-md);
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.modal__close {
+  border: none;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.modal__body {
+  padding: 0 var(--space-xl) var(--space-xl);
+  overflow-y: auto;
+  display: grid;
+  gap: var(--space-md);
+}
+
+.modal__footer {
+  padding: var(--space-sm) var(--space-xl) var(--space-xl);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import './Modal.css';
+
+export const Modal = ({ open, title, onClose, children, footer }) => {
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose?.();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="modal">
+      <div className="modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="modal__dialog" role="dialog" aria-modal="true">
+        <header className="modal__header">
+          <h2 className="modal__title">{title}</h2>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Закрыть модальное окно">
+            ×
+          </button>
+        </header>
+        <div className="modal__body">{children}</div>
+        {footer && <footer className="modal__footer">{footer}</footer>}
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/common/Tag.css
+++ b/src/components/common/Tag.css
@@ -1,0 +1,26 @@
+.tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: var(--space-3xs) var(--space-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tag--neutral {
+  background: rgba(148, 163, 184, 0.14);
+  color: rgb(71, 85, 105);
+}
+
+.tag--accent {
+  background: rgba(45, 212, 191, 0.14);
+  color: rgb(13, 148, 136);
+}
+
+.tag--warning {
+  background: rgba(251, 191, 36, 0.2);
+  color: rgb(180, 83, 9);
+}
+

--- a/src/components/common/Tag.js
+++ b/src/components/common/Tag.js
@@ -1,0 +1,6 @@
+import './Tag.css';
+
+export const Tag = ({ tone = 'neutral', children }) => (
+  <span className={`tag tag--${tone}`}>{children}</span>
+);
+

--- a/src/components/forms/FormField.css
+++ b/src/components/forms/FormField.css
@@ -1,0 +1,50 @@
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+}
+
+.form-field__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted-strong);
+}
+
+.form-field__input {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(255, 255, 255, 0.92);
+  font-size: 1rem;
+  transition: border 140ms ease, box-shadow 140ms ease;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.form-field__input:focus {
+  outline: none;
+  border-color: rgba(255, 126, 95, 0.8);
+  box-shadow: 0 0 0 3px rgba(255, 126, 95, 0.2);
+}
+
+.form-field__input--textarea {
+  min-height: 120px;
+}
+
+.form-field__hint {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.form-field__error {
+  font-size: 0.8rem;
+  color: rgb(220, 38, 38);
+}
+
+.form-field--error .form-field__input {
+  border-color: rgba(220, 38, 38, 0.7);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18);
+}
+

--- a/src/components/forms/FormField.js
+++ b/src/components/forms/FormField.js
@@ -1,0 +1,32 @@
+import './FormField.css';
+
+export const FormField = ({ label, hint, error, children }) => (
+  <label className={`form-field ${error ? 'form-field--error' : ''}`}>
+    <span className="form-field__label">{label}</span>
+    {children}
+    {hint && !error && <span className="form-field__hint">{hint}</span>}
+    {error && <span className="form-field__error">{error}</span>}
+  </label>
+);
+
+export const TextInput = ({ multiline, rows = 3, ...props }) => {
+  if (multiline) {
+    return <textarea rows={rows} className="form-field__input form-field__input--textarea" {...props} />;
+  }
+
+  return <input className="form-field__input" {...props} />;
+};
+
+export const SelectInput = ({ options = [], placeholder = 'Выберите', ...props }) => (
+  <select className="form-field__input" {...props}>
+    <option value="" disabled>
+      {placeholder}
+    </option>
+    {options.map((option) => (
+      <option key={option.value} value={option.value}>
+        {option.label}
+      </option>
+    ))}
+  </select>
+);
+

--- a/src/components/layout/AppLayout.css
+++ b/src/components/layout/AppLayout.css
@@ -1,0 +1,183 @@
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, rgba(255, 193, 134, 0.25), transparent 60%),
+    var(--color-surface);
+}
+
+.app-shell__header {
+  padding: var(--space-lg) var(--space-md) var(--space-sm);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: white;
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  box-shadow: 0 8px 24px rgba(17, 24, 39, 0.18);
+}
+
+.app-shell__header-content {
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.app-shell__subtitle {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 0 0 var(--space-2xs);
+  opacity: 0.8;
+}
+
+.app-shell__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.8vw, 2.4rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.app-shell__actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.app-shell__body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-md);
+  padding: 0 var(--space-md) var(--space-2xl);
+  max-width: var(--layout-max-width);
+  width: 100%;
+  margin: 0 auto;
+}
+
+.app-shell__sidebar {
+  display: none;
+}
+
+.app-shell__nav {
+  position: sticky;
+  top: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.nav-btn {
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: var(--space-sm) var(--space-md);
+  background: transparent;
+  color: var(--color-muted);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  transition: transform 120ms ease, background 160ms ease, color 160ms ease;
+}
+
+.nav-btn:hover,
+.nav-btn:focus-visible {
+  color: var(--color-primary);
+  transform: translateX(4px);
+}
+
+.nav-btn--active {
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--color-primary-strong);
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.08);
+}
+
+.nav-btn__icon {
+  font-size: 1.2rem;
+}
+
+.nav-btn__label {
+  font-size: 0.95rem;
+}
+
+.app-shell__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.app-shell__footer {
+  position: sticky;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(16px);
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding: var(--space-xs) var(--space-md);
+  z-index: 5;
+}
+
+.bottom-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-xs);
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+}
+
+.bottom-nav__item {
+  flex: 1;
+  border: none;
+  border-radius: var(--radius-xl);
+  padding: var(--space-xs);
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 0.8rem;
+  font-weight: 500;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3xs);
+}
+
+.bottom-nav__item--active {
+  background: var(--color-primary-tint);
+  color: var(--color-primary-strong);
+  box-shadow: 0 10px 24px rgba(255, 126, 95, 0.18);
+}
+
+.bottom-nav__icon {
+  font-size: 1.4rem;
+}
+
+.bottom-nav__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@media (min-width: 960px) {
+  .app-shell {
+    background: linear-gradient(180deg, rgba(255, 241, 229, 0.65), transparent),
+      var(--color-surface);
+  }
+
+  .app-shell__header {
+    padding: var(--space-xl) var(--space-2xl) var(--space-lg);
+  }
+
+  .app-shell__body {
+    grid-template-columns: 220px minmax(0, 1fr);
+    align-items: flex-start;
+    padding-bottom: var(--space-3xl);
+  }
+
+  .app-shell__sidebar {
+    display: block;
+  }
+
+  .app-shell__footer {
+    display: none;
+  }
+}
+

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -1,0 +1,72 @@
+import './AppLayout.css';
+
+const defaultNavItems = [
+  { id: 'planner', label: 'План', icon: '🗓️' },
+  { id: 'dishes', label: 'Блюда', icon: '🍽️' },
+  { id: 'products', label: 'Продукты', icon: '🧺' },
+];
+
+export const AppLayout = ({
+  activeView,
+  onChangeView,
+  title,
+  subtitle,
+  actions,
+  navigationItems = defaultNavItems,
+  children,
+  footer,
+}) => (
+  <div className="app-shell">
+    <header className="app-shell__header">
+      <div className="app-shell__header-content">
+        <div>
+          <p className="app-shell__subtitle">{subtitle}</p>
+          <h1 className="app-shell__title">{title}</h1>
+        </div>
+        {actions && <div className="app-shell__actions">{actions}</div>}
+      </div>
+    </header>
+
+    <div className="app-shell__body">
+      <aside className="app-shell__sidebar" aria-label="Навигация по разделам">
+        <nav className="app-shell__nav">
+          {navigationItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={item.id === activeView ? 'nav-btn nav-btn--active' : 'nav-btn'}
+              onClick={() => onChangeView(item.id)}
+            >
+              <span className="nav-btn__icon" aria-hidden>
+                {item.icon}
+              </span>
+              <span className="nav-btn__label">{item.label}</span>
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      <main className="app-shell__content">{children}</main>
+    </div>
+
+    <footer className="app-shell__footer">
+      <nav className="bottom-nav" aria-label="Навигация по разделам (мобильная)">
+        {navigationItems.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={item.id === activeView ? 'bottom-nav__item bottom-nav__item--active' : 'bottom-nav__item'}
+            onClick={() => onChangeView(item.id)}
+          >
+            <span className="bottom-nav__icon" aria-hidden>
+              {item.icon}
+            </span>
+            <span className="bottom-nav__label">{item.label}</span>
+          </button>
+        ))}
+      </nav>
+      {footer}
+    </footer>
+  </div>
+);
+

--- a/src/hooks/usePlannerData.js
+++ b/src/hooks/usePlannerData.js
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import * as dishesApi from '../api/dishes';
+import * as productsApi from '../api/products';
+import * as mealGroupsApi from '../api/mealGroups';
+import * as dishProductsApi from '../api/dishProducts';
+import * as mealGroupDishesApi from '../api/mealGroupDishes';
+
+const extractErrorMessage = (error) => {
+  if (!error) {
+    return null;
+  }
+
+  if (error.payload?.message) {
+    return error.payload.message;
+  }
+
+  if (typeof error.payload === 'string' && error.payload.trim().length > 0) {
+    return error.payload;
+  }
+
+  if (error.status === 404) {
+    return 'Запрашиваемый ресурс не найден.';
+  }
+
+  if (error.status === 409) {
+    return 'Такая запись уже существует. Обновите данные и попробуйте снова.';
+  }
+
+  return 'Не удалось выполнить запрос. Проверьте подключение или попробуйте ещё раз.';
+};
+
+export const usePlannerData = () => {
+  const [dishes, setDishes] = useState([]);
+  const [products, setProducts] = useState([]);
+  const [mealGroups, setMealGroups] = useState([]);
+  const [dishProducts, setDishProducts] = useState([]);
+  const [mealGroupDishes, setMealGroupDishes] = useState([]);
+
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [isMutating, setIsMutating] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleError = useCallback((err) => {
+    console.error(err);
+    setError(extractErrorMessage(err));
+    return err;
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const loadDishes = useCallback(async () => {
+    const data = await dishesApi.fetchDishes();
+    setDishes(data ?? []);
+    return data;
+  }, []);
+
+  const loadProducts = useCallback(async () => {
+    const data = await productsApi.fetchProducts();
+    setProducts(data ?? []);
+    return data;
+  }, []);
+
+  const loadMealGroups = useCallback(async () => {
+    const data = await mealGroupsApi.fetchMealGroups();
+    setMealGroups(data ?? []);
+    return data;
+  }, []);
+
+  const loadDishProducts = useCallback(async () => {
+    const data = await dishProductsApi.fetchDishProducts();
+    setDishProducts(data ?? []);
+    return data;
+  }, []);
+
+  const loadMealGroupDishes = useCallback(async () => {
+    const data = await mealGroupDishesApi.fetchMealGroupDishes();
+    setMealGroupDishes(data ?? []);
+    return data;
+  }, []);
+
+  const loadAll = useCallback(async () => {
+    setInitialLoading(true);
+    clearError();
+
+    try {
+      await Promise.all([
+        loadDishes(),
+        loadProducts(),
+        loadMealGroups(),
+        loadDishProducts(),
+        loadMealGroupDishes(),
+      ]);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setInitialLoading(false);
+    }
+  }, [clearError, handleError, loadDishProducts, loadDishes, loadMealGroupDishes, loadMealGroups, loadProducts]);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  const runMutation = useCallback(
+    async (mutation, refreshers = []) => {
+      clearError();
+      setIsMutating(true);
+
+      try {
+        await mutation();
+        await Promise.all(refreshers.map((ref) => ref()));
+      } catch (err) {
+        throw handleError(err);
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [clearError, handleError],
+  );
+
+  const value = useMemo(
+    () => ({
+      dishes,
+      products,
+      mealGroups,
+      dishProducts,
+      mealGroupDishes,
+      loading: initialLoading,
+      error,
+      isMutating,
+      refresh: loadAll,
+      clearError,
+      async createDish(payload) {
+        await runMutation(() => dishesApi.createDish(payload), [loadDishes]);
+      },
+      async updateDish(id, payload) {
+        await runMutation(() => dishesApi.updateDish(id, payload), [loadDishes]);
+      },
+      async deleteDish(id) {
+        await runMutation(() => dishesApi.deleteDish(id), [loadDishes, loadMealGroups, loadDishProducts]);
+      },
+      async createProduct(payload) {
+        await runMutation(() => productsApi.createProduct(payload), [loadProducts]);
+      },
+      async updateProduct(id, payload) {
+        await runMutation(() => productsApi.updateProduct(id, payload), [loadProducts]);
+      },
+      async deleteProduct(id) {
+        await runMutation(() => productsApi.deleteProduct(id), [loadProducts, loadDishes, loadDishProducts]);
+      },
+      async createMealGroup(payload) {
+        await runMutation(() => mealGroupsApi.createMealGroup(payload), [loadMealGroups]);
+      },
+      async updateMealGroup(id, payload) {
+        await runMutation(() => mealGroupsApi.updateMealGroup(id, payload), [loadMealGroups]);
+      },
+      async deleteMealGroup(id) {
+        await runMutation(() => mealGroupsApi.deleteMealGroup(id), [loadMealGroups, loadMealGroupDishes]);
+      },
+      async createDishProduct(payload) {
+        await runMutation(() => dishProductsApi.createDishProduct(payload), [loadDishProducts, loadDishes]);
+      },
+      async updateDishProduct(dishId, productId, payload) {
+        await runMutation(
+          () => dishProductsApi.updateDishProduct(dishId, productId, payload),
+          [loadDishProducts, loadDishes],
+        );
+      },
+      async deleteDishProduct(dishId, productId) {
+        await runMutation(
+          () => dishProductsApi.deleteDishProduct(dishId, productId),
+          [loadDishProducts, loadDishes],
+        );
+      },
+      async createMealGroupDish(payload) {
+        await runMutation(
+          () => mealGroupDishesApi.createMealGroupDish(payload),
+          [loadMealGroupDishes, loadMealGroups, loadDishes],
+        );
+      },
+      async updateMealGroupDish(mealGroupId, dishId, payload) {
+        await runMutation(
+          () => mealGroupDishesApi.updateMealGroupDish(mealGroupId, dishId, payload),
+          [loadMealGroupDishes, loadMealGroups, loadDishes],
+        );
+      },
+      async deleteMealGroupDish(mealGroupId, dishId) {
+        await runMutation(
+          () => mealGroupDishesApi.deleteMealGroupDish(mealGroupId, dishId),
+          [loadMealGroupDishes, loadMealGroups, loadDishes],
+        );
+      },
+    }),
+    [
+      clearError,
+      dishProducts,
+      dishes,
+      error,
+      initialLoading,
+      isMutating,
+      loadAll,
+      loadDishProducts,
+      loadDishes,
+      loadMealGroupDishes,
+      loadMealGroups,
+      loadProducts,
+      mealGroupDishes,
+      mealGroups,
+      products,
+      runMutation,
+    ],
+  );
+
+  return value;
+};
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,74 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+:root {
+  --color-primary: #ff7e5f;
+  --color-secondary: #feb47b;
+  --color-primary-tint: rgba(255, 126, 95, 0.15);
+  --color-primary-strong: #e05a3a;
+  --color-surface: #f8fafc;
+  --color-text: #1f2937;
+  --color-text-strong: #0f172a;
+  --color-muted: #64748b;
+  --color-muted-strong: #475569;
+
+  --space-4xs: 0.125rem;
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.375rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 2.5rem;
+  --space-3xl: 3rem;
+
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-2xl: 32px;
+
+  --layout-max-width: 1100px;
+
+  --shadow-soft: 0 20px 50px rgba(15, 23, 42, 0.08);
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+* {
+  box-sizing: border-box;
 }
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'SF Pro Display', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont,
+    'Roboto', sans-serif;
+  background: var(--color-surface);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Inter', 'SF Pro Display', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont,
+    'Roboto', sans-serif;
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+button,
+input,
+textarea,
+select {
+  font-family: inherit;
+}
+
+#root {
+  min-height: 100vh;
+}
+

--- a/src/pages/DishesPage.js
+++ b/src/pages/DishesPage.js
@@ -1,0 +1,361 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardFooter, CardHeader } from '../components/common/Card';
+import { Button } from '../components/common/Button';
+import { Modal } from '../components/common/Modal';
+import { FormField, SelectInput, TextInput } from '../components/forms/FormField';
+import { Tag } from '../components/common/Tag';
+import { EmptyState } from '../components/common/EmptyState';
+
+const defaultDish = {
+  name: '',
+  description: '',
+  instructions: '',
+  preparationMinutes: '',
+  imageUrl: '',
+};
+
+const defaultIngredient = {
+  dishId: null,
+  productId: '',
+  quantity: '',
+};
+
+export const DishesPage = ({
+  dishes,
+  products,
+  createDish,
+  updateDish,
+  deleteDish,
+  createDishProduct,
+  updateDishProduct,
+  deleteDishProduct,
+  isMutating,
+}) => {
+  const [isDishModalOpen, setDishModalOpen] = useState(false);
+  const [editingDish, setEditingDish] = useState(null);
+  const [dishForm, setDishForm] = useState(defaultDish);
+  const [dishErrors, setDishErrors] = useState({});
+
+  const [isIngredientModalOpen, setIngredientModalOpen] = useState(false);
+  const [ingredientForm, setIngredientForm] = useState(defaultIngredient);
+  const [editingIngredient, setEditingIngredient] = useState(null);
+
+  const productOptions = useMemo(
+    () => products.map((product) => ({ label: product.name, value: String(product.id) })),
+    [products],
+  );
+
+  const openCreateDishModal = () => {
+    setEditingDish(null);
+    setDishForm(defaultDish);
+    setDishErrors({});
+    setDishModalOpen(true);
+  };
+
+  const openEditDishModal = (dish) => {
+    setEditingDish(dish);
+    setDishForm({
+      name: dish.name ?? '',
+      description: dish.description ?? '',
+      instructions: dish.instructions ?? '',
+      preparationMinutes: dish.preparationMinutes ?? '',
+      imageUrl: dish.imageUrl ?? '',
+    });
+    setDishErrors({});
+    setDishModalOpen(true);
+  };
+
+  const closeDishModal = () => {
+    setDishModalOpen(false);
+    setEditingDish(null);
+    setDishForm(defaultDish);
+  };
+
+  const submitDish = async () => {
+    if (!dishForm.name.trim()) {
+      setDishErrors({ name: 'Название обязательно' });
+      return;
+    }
+
+    const payload = {
+      name: dishForm.name.trim(),
+      description: dishForm.description.trim() || null,
+      instructions: dishForm.instructions.trim() || null,
+      preparationMinutes: dishForm.preparationMinutes
+        ? Number(dishForm.preparationMinutes)
+        : null,
+      imageUrl: dishForm.imageUrl.trim() || null,
+    };
+
+    if (editingDish) {
+      await updateDish(editingDish.id, payload);
+    } else {
+      await createDish(payload);
+    }
+
+    closeDishModal();
+  };
+
+  const openIngredientModal = (dish, ingredient) => {
+    setEditingIngredient(ingredient ?? null);
+    setIngredientForm({
+      dishId: dish.id,
+      productId: ingredient ? String(ingredient.productId) : '',
+      quantity: ingredient?.quantity ?? '',
+    });
+    setIngredientModalOpen(true);
+  };
+
+  const closeIngredientModal = () => {
+    setIngredientForm(defaultIngredient);
+    setEditingIngredient(null);
+    setIngredientModalOpen(false);
+  };
+
+  const submitIngredient = async () => {
+    if (!ingredientForm.productId) {
+      return;
+    }
+
+    const payload = {
+      dishId: Number(ingredientForm.dishId),
+      productId: Number(ingredientForm.productId),
+      quantity: ingredientForm.quantity ? String(ingredientForm.quantity) : null,
+    };
+
+    if (editingIngredient) {
+      await updateDishProduct(payload.dishId, editingIngredient.productId, {
+        quantity: payload.quantity,
+      });
+    } else {
+      await createDishProduct(payload);
+    }
+
+    closeIngredientModal();
+  };
+
+  const availableProducts = useMemo(() => {
+    if (!ingredientForm.dishId) {
+      return productOptions;
+    }
+
+    const dish = dishes.find((item) => item.id === ingredientForm.dishId);
+    if (!dish) {
+      return productOptions;
+    }
+
+    const usedProductIds = dish.products?.map((product) => product.productId) ?? [];
+
+    if (editingIngredient) {
+      return productOptions;
+    }
+
+    return productOptions.filter((option) => !usedProductIds.includes(Number(option.value)));
+  }, [dishes, editingIngredient, ingredientForm.dishId, productOptions]);
+
+  return (
+    <div className="page">
+      <div className="page__header">
+        <h2 className="page__title">Блюда</h2>
+        <Button onClick={openCreateDishModal}>Новое блюдо</Button>
+      </div>
+
+      {dishes.length === 0 ? (
+        <EmptyState
+          title="Список блюд пуст"
+          description="Добавьте любимые рецепты и планируйте меню в один клик."
+          action={<Button onClick={openCreateDishModal}>Добавить блюдо</Button>}
+        />
+      ) : (
+        <div className="stack">
+          {dishes.map((dish) => (
+            <Card key={dish.id} className="dish-card">
+              <CardHeader
+                title={dish.name}
+                subtitle={dish.description}
+                endSlot={
+                  <div className="card-action-buttons">
+                    <Button variant="ghost" onClick={() => openEditDishModal(dish)}>
+                      Редактировать
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onClick={() => deleteDish(dish.id)}
+                      disabled={isMutating}
+                    >
+                      Удалить
+                    </Button>
+                  </div>
+                }
+              />
+
+              <CardContent>
+                {dish.imageUrl && (
+                  <img src={dish.imageUrl} alt="Блюдо" className="dish-card__image" loading="lazy" />
+                )}
+                <div className="dish-card__info">
+                  {dish.preparationMinutes ? (
+                    <Tag tone="warning">{dish.preparationMinutes} мин.</Tag>
+                  ) : (
+                    <span className="muted">Время готовки не указано</span>
+                  )}
+
+                  {dish.instructions ? (
+                    <p className="multiline">{dish.instructions}</p>
+                  ) : (
+                    <p className="muted">Нет инструкций по приготовлению</p>
+                  )}
+                </div>
+
+                <div className="dish-card__ingredients">
+                  <div className="section-header">
+                    <h3>Ингредиенты</h3>
+                    <Button variant="ghost" onClick={() => openIngredientModal(dish)}>
+                      Добавить
+                    </Button>
+                  </div>
+                  {dish.products?.length ? (
+                    <ul className="ingredient-list">
+                      {dish.products.map((product) => (
+                        <li key={product.productId} className="ingredient-list__item">
+                          <div>
+                            <strong>{product.productName}</strong>
+                            {product.quantity && <p className="muted">{product.quantity}</p>}
+                          </div>
+                          <div className="ingredient-list__actions">
+                            <Button
+                              variant="ghost"
+                              onClick={() => openIngredientModal(dish, product)}
+                              disabled={isMutating}
+                            >
+                              Изменить
+                            </Button>
+                            <Button
+                              variant="danger"
+                              onClick={() => deleteDishProduct(dish.id, product.productId)}
+                              disabled={isMutating}
+                            >
+                              Удалить
+                            </Button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="muted">Ингредиенты ещё не добавлены</p>
+                  )}
+                </div>
+              </CardContent>
+
+              <CardFooter>
+                <Button variant="ghost" onClick={() => openIngredientModal(dish)}>
+                  Добавить ингредиент
+                </Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        open={isDishModalOpen}
+        title={editingDish ? 'Редактирование блюда' : 'Новое блюдо'}
+        onClose={closeDishModal}
+        footer={
+          <>
+            <Button variant="ghost" onClick={closeDishModal} disabled={isMutating}>
+              Отмена
+            </Button>
+            <Button onClick={submitDish} disabled={isMutating}>
+              {editingDish ? 'Сохранить' : 'Добавить'}
+            </Button>
+          </>
+        }
+      >
+        <FormField label="Название" error={dishErrors.name}>
+          <TextInput
+            value={dishForm.name}
+            onChange={(event) => setDishForm((state) => ({ ...state, name: event.target.value }))}
+            placeholder="Например, Омлет с овощами"
+          />
+        </FormField>
+
+        <FormField label="Описание">
+          <TextInput
+            multiline
+            rows={3}
+            value={dishForm.description}
+            onChange={(event) => setDishForm((state) => ({ ...state, description: event.target.value }))}
+            placeholder="Небольшое описание вкуса или подачи"
+          />
+        </FormField>
+
+        <FormField label="Инструкции">
+          <TextInput
+            multiline
+            rows={5}
+            value={dishForm.instructions}
+            onChange={(event) => setDishForm((state) => ({ ...state, instructions: event.target.value }))}
+            placeholder="Шаги приготовления"
+          />
+        </FormField>
+
+        <FormField label="Время приготовления (мин)" hint="Если блюдо готовится быстро — отметьте это!">
+          <TextInput
+            type="number"
+            min="0"
+            value={dishForm.preparationMinutes}
+            onChange={(event) => setDishForm((state) => ({ ...state, preparationMinutes: event.target.value }))}
+            placeholder="15"
+          />
+        </FormField>
+
+        <FormField label="Ссылка на изображение" hint="Добавьте красивую картинку">
+          <TextInput
+            type="url"
+            value={dishForm.imageUrl}
+            onChange={(event) => setDishForm((state) => ({ ...state, imageUrl: event.target.value }))}
+            placeholder="https://..."
+          />
+        </FormField>
+      </Modal>
+
+      <Modal
+        open={isIngredientModalOpen}
+        title={editingIngredient ? 'Изменить ингредиент' : 'Добавить ингредиент'}
+        onClose={closeIngredientModal}
+        footer={
+          <>
+            <Button variant="ghost" onClick={closeIngredientModal} disabled={isMutating}>
+              Отмена
+            </Button>
+            <Button onClick={submitIngredient} disabled={!ingredientForm.productId || isMutating}>
+              {editingIngredient ? 'Сохранить' : 'Добавить'}
+            </Button>
+          </>
+        }
+      >
+        <FormField label="Продукт">
+          <SelectInput
+            value={ingredientForm.productId}
+            onChange={(event) =>
+              setIngredientForm((state) => ({ ...state, productId: event.target.value }))
+            }
+            options={availableProducts}
+            disabled={availableProducts.length === 0}
+            placeholder={availableProducts.length ? 'Выберите продукт' : 'Нет доступных продуктов'}
+          />
+        </FormField>
+
+        <FormField label="Количество" hint="Например, 2 яйца или 150 г">
+          <TextInput
+            value={ingredientForm.quantity}
+            onChange={(event) => setIngredientForm((state) => ({ ...state, quantity: event.target.value }))}
+            placeholder="Количество ингредиента"
+          />
+        </FormField>
+      </Modal>
+    </div>
+  );
+};
+

--- a/src/pages/MealPlannerPage.js
+++ b/src/pages/MealPlannerPage.js
@@ -1,0 +1,250 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardFooter, CardHeader } from '../components/common/Card';
+import { Button } from '../components/common/Button';
+import { Tag } from '../components/common/Tag';
+import { Modal } from '../components/common/Modal';
+import { FormField, SelectInput, TextInput } from '../components/forms/FormField';
+import { EmptyState } from '../components/common/EmptyState';
+
+const defaultGroup = {
+  name: '',
+  description: '',
+  accentColor: '#ff7e5f',
+};
+
+export const MealPlannerPage = ({
+  mealGroups,
+  dishes,
+  createMealGroup,
+  updateMealGroup,
+  deleteMealGroup,
+  createMealGroupDish,
+  deleteMealGroupDish,
+  isMutating,
+}) => {
+  const [isGroupModalOpen, setGroupModalOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState(null);
+  const [groupForm, setGroupForm] = useState(defaultGroup);
+  const [groupErrors, setGroupErrors] = useState({});
+
+  const [isAssignModalOpen, setAssignModalOpen] = useState(false);
+  const [selectedGroupId, setSelectedGroupId] = useState(null);
+  const [selectedDishId, setSelectedDishId] = useState('');
+
+  const groupOptions = useMemo(
+    () => dishes.map((dish) => ({ label: dish.name, value: String(dish.id) })),
+    [dishes],
+  );
+
+  const resetGroupModal = () => {
+    setGroupModalOpen(false);
+    setEditingGroup(null);
+    setGroupForm(defaultGroup);
+    setGroupErrors({});
+  };
+
+  const openCreateModal = () => {
+    setEditingGroup(null);
+    setGroupForm(defaultGroup);
+    setGroupModalOpen(true);
+  };
+
+  const openEditModal = (group) => {
+    setEditingGroup(group);
+    setGroupForm({
+      name: group.name ?? '',
+      description: group.description ?? '',
+      accentColor: group.accentColor ?? '#ff7e5f',
+    });
+    setGroupModalOpen(true);
+  };
+
+  const submitGroup = async () => {
+    if (!groupForm.name.trim()) {
+      setGroupErrors({ name: 'Название обязательно' });
+      return;
+    }
+
+    const payload = {
+      name: groupForm.name.trim(),
+      description: groupForm.description.trim() || null,
+      accentColor: groupForm.accentColor,
+    };
+
+    if (editingGroup) {
+      await updateMealGroup(editingGroup.id, payload);
+    } else {
+      await createMealGroup(payload);
+    }
+
+    resetGroupModal();
+  };
+
+  const openAssignDishModal = (groupId) => {
+    setSelectedGroupId(groupId);
+    setSelectedDishId('');
+    setAssignModalOpen(true);
+  };
+
+  const submitAssignDish = async () => {
+    if (!selectedDishId || !selectedGroupId) {
+      return;
+    }
+
+    await createMealGroupDish({
+      mealGroupId: Number(selectedGroupId),
+      dishId: Number(selectedDishId),
+    });
+
+    setAssignModalOpen(false);
+  };
+
+  const selectedGroup = mealGroups.find((group) => group.id === selectedGroupId);
+  const selectedGroupDishIds = selectedGroup?.dishes?.map((item) => item.dishId) ?? [];
+
+  const filteredGroupOptions = groupOptions.filter((option) => !selectedGroupDishIds.includes(Number(option.value)));
+
+  return (
+    <div className="page">
+      <div className="page__header">
+        <h2 className="page__title">Наборы приёмов пищи</h2>
+        <Button onClick={openCreateModal}>Новый набор</Button>
+      </div>
+
+      {mealGroups.length === 0 ? (
+        <EmptyState
+          title="Наборы ещё не созданы"
+          description="Создайте наборы, чтобы собрать план питания на неделю."
+          action={<Button onClick={openCreateModal}>Создать набор</Button>}
+        />
+      ) : (
+        <div className="grid grid--responsive">
+          {mealGroups.map((group) => (
+            <Card key={group.id} className="meal-group-card">
+              <CardHeader
+                title={group.name}
+                subtitle={group.description}
+                endSlot={
+                  <div className="card-action-buttons">
+                    <Button variant="ghost" onClick={() => openAssignDishModal(group.id)}>
+                      Добавить блюдо
+                    </Button>
+                    <Button variant="ghost" onClick={() => openEditModal(group)}>
+                      Редактировать
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onClick={() => deleteMealGroup(group.id)}
+                      disabled={isMutating}
+                    >
+                      Удалить
+                    </Button>
+                  </div>
+                }
+              />
+
+              <CardContent>
+                <div className="meal-group-card__accent" style={{ background: group.accentColor }} />
+                {group.dishes?.length ? (
+                  <ul className="chip-list">
+                    {group.dishes.map((dish) => (
+                      <li key={dish.dishId} className="chip-list__item">
+                        <Tag tone="accent">{dish.dishName}</Tag>
+                        <button
+                          type="button"
+                          className="chip-list__remove"
+                          onClick={() => deleteMealGroupDish(group.id, dish.dishId)}
+                          aria-label={`Убрать блюдо ${dish.dishName}`}
+                          disabled={isMutating}
+                        >
+                          ×
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="muted">Блюда пока не добавлены.</p>
+                )}
+              </CardContent>
+
+              <CardFooter>
+                <Button variant="ghost" onClick={() => openAssignDishModal(group.id)}>
+                  Подобрать блюдо
+                </Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        open={isGroupModalOpen}
+        title={editingGroup ? 'Редактирование набора' : 'Новый набор'}
+        onClose={resetGroupModal}
+        footer={
+          <>
+            <Button variant="ghost" onClick={resetGroupModal} disabled={isMutating}>
+              Отмена
+            </Button>
+            <Button onClick={submitGroup} disabled={isMutating}>
+              {editingGroup ? 'Сохранить' : 'Создать'}
+            </Button>
+          </>
+        }
+      >
+        <FormField label="Название" error={groupErrors.name}>
+          <TextInput
+            value={groupForm.name}
+            onChange={(event) => setGroupForm((state) => ({ ...state, name: event.target.value }))}
+            placeholder="Например, Завтрак"
+          />
+        </FormField>
+
+        <FormField label="Описание" hint="Добавьте короткую заметку или настроение">
+          <TextInput
+            multiline
+            rows={4}
+            value={groupForm.description}
+            onChange={(event) => setGroupForm((state) => ({ ...state, description: event.target.value }))}
+            placeholder="Лёгкий и бодрый старт дня"
+          />
+        </FormField>
+
+        <FormField label="Цвет акцента" hint="Используется в карточках и тегах">
+          <TextInput
+            type="color"
+            value={groupForm.accentColor}
+            onChange={(event) => setGroupForm((state) => ({ ...state, accentColor: event.target.value }))}
+          />
+        </FormField>
+      </Modal>
+
+      <Modal
+        open={isAssignModalOpen}
+        title="Добавить блюдо в набор"
+        onClose={() => setAssignModalOpen(false)}
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setAssignModalOpen(false)} disabled={isMutating}>
+              Отмена
+            </Button>
+            <Button onClick={submitAssignDish} disabled={!selectedDishId || isMutating}>
+              Добавить
+            </Button>
+          </>
+        }
+      >
+        <FormField label="Блюдо" hint="Можно добавить любое блюдо из списка">
+          <SelectInput
+            value={selectedDishId}
+            onChange={(event) => setSelectedDishId(event.target.value)}
+            options={filteredGroupOptions}
+            placeholder={filteredGroupOptions.length ? 'Выберите блюдо' : 'Все блюда уже добавлены'}
+            disabled={filteredGroupOptions.length === 0}
+          />
+        </FormField>
+      </Modal>
+    </div>
+  );
+};
+

--- a/src/pages/ProductsPage.js
+++ b/src/pages/ProductsPage.js
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import { Card, CardContent, CardFooter, CardHeader } from '../components/common/Card';
+import { Button } from '../components/common/Button';
+import { Modal } from '../components/common/Modal';
+import { FormField, TextInput } from '../components/forms/FormField';
+import { Tag } from '../components/common/Tag';
+import { EmptyState } from '../components/common/EmptyState';
+
+const defaultProduct = {
+  name: '',
+  category: '',
+  notes: '',
+};
+
+export const ProductsPage = ({ products, createProduct, updateProduct, deleteProduct, isMutating }) => {
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [editingProduct, setEditingProduct] = useState(null);
+  const [productForm, setProductForm] = useState(defaultProduct);
+  const [productErrors, setProductErrors] = useState({});
+
+  const openCreateModal = () => {
+    setEditingProduct(null);
+    setProductForm(defaultProduct);
+    setProductErrors({});
+    setModalOpen(true);
+  };
+
+  const openEditModal = (product) => {
+    setEditingProduct(product);
+    setProductForm({
+      name: product.name ?? '',
+      category: product.category ?? '',
+      notes: product.notes ?? '',
+    });
+    setProductErrors({});
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setEditingProduct(null);
+    setProductForm(defaultProduct);
+  };
+
+  const submitProduct = async () => {
+    if (!productForm.name.trim()) {
+      setProductErrors({ name: 'Название обязательно' });
+      return;
+    }
+
+    const payload = {
+      name: productForm.name.trim(),
+      category: productForm.category.trim() || null,
+      notes: productForm.notes.trim() || null,
+    };
+
+    if (editingProduct) {
+      await updateProduct(editingProduct.id, payload);
+    } else {
+      await createProduct(payload);
+    }
+
+    closeModal();
+  };
+
+  return (
+    <div className="page">
+      <div className="page__header">
+        <h2 className="page__title">Продукты</h2>
+        <Button onClick={openCreateModal}>Новый продукт</Button>
+      </div>
+
+      {products.length === 0 ? (
+        <EmptyState
+          title="Список продуктов пуст"
+          description="Добавьте продукты из холодильника и создавайте блюда быстрее."
+          action={<Button onClick={openCreateModal}>Добавить продукт</Button>}
+        />
+      ) : (
+        <div className="stack">
+          {products.map((product) => (
+            <Card key={product.id} className="product-card">
+              <CardHeader
+                title={product.name}
+                subtitle={product.category}
+                endSlot={
+                  <div className="card-action-buttons">
+                    <Button variant="ghost" onClick={() => openEditModal(product)}>
+                      Редактировать
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onClick={() => deleteProduct(product.id)}
+                      disabled={isMutating}
+                    >
+                      Удалить
+                    </Button>
+                  </div>
+                }
+              />
+
+              <CardContent>
+                {product.notes ? <p className="multiline">{product.notes}</p> : <p className="muted">Нет заметок</p>}
+
+                <div className="product-card__dishes">
+                  <div className="section-header">
+                    <h3>Используется в блюдах</h3>
+                  </div>
+                  {product.dishes?.length ? (
+                    <ul className="chip-list">
+                      {product.dishes.map((dish) => (
+                        <li key={dish.dishId} className="chip-list__item chip-list__item--static">
+                          <Tag tone="accent">{dish.dishName}</Tag>
+                          {dish.quantity && <span className="muted">{dish.quantity}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="muted">Пока не используется ни в одном блюде</p>
+                  )}
+                </div>
+              </CardContent>
+
+              <CardFooter />
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        open={isModalOpen}
+        title={editingProduct ? 'Редактирование продукта' : 'Новый продукт'}
+        onClose={closeModal}
+        footer={
+          <>
+            <Button variant="ghost" onClick={closeModal} disabled={isMutating}>
+              Отмена
+            </Button>
+            <Button onClick={submitProduct} disabled={isMutating}>
+              {editingProduct ? 'Сохранить' : 'Добавить'}
+            </Button>
+          </>
+        }
+      >
+        <FormField label="Название" error={productErrors.name}>
+          <TextInput
+            value={productForm.name}
+            onChange={(event) => setProductForm((state) => ({ ...state, name: event.target.value }))}
+            placeholder="Например, Авокадо"
+          />
+        </FormField>
+
+        <FormField label="Категория" hint="Овощи, молочные продукты, крупы и т.д.">
+          <TextInput
+            value={productForm.category}
+            onChange={(event) => setProductForm((state) => ({ ...state, category: event.target.value }))}
+            placeholder="Категория"
+          />
+        </FormField>
+
+        <FormField label="Заметки" hint="Например, производителя или срок годности">
+          <TextInput
+            multiline
+            rows={4}
+            value={productForm.notes}
+            onChange={(event) => setProductForm((state) => ({ ...state, notes: event.target.value }))}
+            placeholder="Хранить в холодильнике, использовать до пятницы"
+          />
+        </FormField>
+      </Modal>
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- build a responsive single-page layout with dedicated views for planner, dishes, and products
- add API client, hooks, and rich CRUD workflows for dishes, ingredients, products, and meal groups
- refresh styling with reusable UI components, modals, and empty/loading states for a mobile-first experience

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dfb408ceb0833090f7baf4642c5068