### PR TITLE
Style meal planner cards with gradient accent strip

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,7 +74,7 @@
   border-radius: var(--radius-2xl);
   pointer-events: none;
   z-index: 0;
-  background: linear-gradient(90deg, rgba(255, 126, 95, 1) 0%, rgba(255, 126, 95, 0) 100%);
+  background-color: #ff7e5f;
 }
 
 .meal-group-card .card__header,

--- a/src/App.css
+++ b/src/App.css
@@ -62,13 +62,26 @@
 
 .meal-group-card {
   position: relative;
+  overflow: hidden;
 }
 
 .meal-group-card__accent {
-  width: 60px;
-  height: 6px;
-  border-radius: 999px;
-  margin-bottom: var(--space-sm);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 18px;
+  border-radius: var(--radius-2xl);
+  pointer-events: none;
+  z-index: 0;
+  background: linear-gradient(90deg, rgba(255, 126, 95, 1) 0%, rgba(255, 126, 95, 0) 100%);
+}
+
+.meal-group-card .card__header,
+.meal-group-card .card__content,
+.meal-group-card .card__footer {
+  position: relative;
+  z-index: 1;
 }
 
 .dish-card__info {

--- a/src/App.css
+++ b/src/App.css
@@ -70,7 +70,7 @@
   top: 0;
   bottom: 0;
   left: 0;
-  width: 18px;
+  width: 5px;
   border-radius: var(--radius-2xl);
   pointer-events: none;
   z-index: 0;

--- a/src/pages/MealPlannerPage.js
+++ b/src/pages/MealPlannerPage.js
@@ -14,30 +14,6 @@ const defaultGroup = {
   accentColor: DEFAULT_ACCENT_COLOR,
 };
 
-const createAccentGradient = (color) => {
-  const sourceColor = color || DEFAULT_ACCENT_COLOR;
-  const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(sourceColor);
-
-  if (hexMatch) {
-    let hex = hexMatch[1];
-
-    if (hex.length === 3) {
-      hex = hex
-        .split('')
-        .map((char) => `${char}${char}`)
-        .join('');
-    }
-
-    const r = parseInt(hex.slice(0, 2), 16);
-    const g = parseInt(hex.slice(2, 4), 16);
-    const b = parseInt(hex.slice(4, 6), 16);
-
-    return `linear-gradient(90deg, rgba(${r}, ${g}, ${b}, 1) 0%, rgba(${r}, ${g}, ${b}, 0) 100%)`;
-  }
-
-  return `linear-gradient(90deg, ${sourceColor} 0%, transparent 100%)`;
-};
-
 export const MealPlannerPage = ({
   mealGroups,
   dishes,
@@ -149,7 +125,7 @@ export const MealPlannerPage = ({
             <Card key={group.id} className="meal-group-card">
               <div
                 className="meal-group-card__accent"
-                style={{ background: createAccentGradient(group.accentColor) }}
+                style={{ backgroundColor: group.accentColor || DEFAULT_ACCENT_COLOR }}
               />
               <CardHeader
                 title={group.name}

--- a/src/pages/MealPlannerPage.js
+++ b/src/pages/MealPlannerPage.js
@@ -6,10 +6,36 @@ import { Modal } from '../components/common/Modal';
 import { FormField, SelectInput, TextInput } from '../components/forms/FormField';
 import { EmptyState } from '../components/common/EmptyState';
 
+const DEFAULT_ACCENT_COLOR = '#ff7e5f';
+
 const defaultGroup = {
   name: '',
   description: '',
-  accentColor: '#ff7e5f',
+  accentColor: DEFAULT_ACCENT_COLOR,
+};
+
+const createAccentGradient = (color) => {
+  const sourceColor = color || DEFAULT_ACCENT_COLOR;
+  const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(sourceColor);
+
+  if (hexMatch) {
+    let hex = hexMatch[1];
+
+    if (hex.length === 3) {
+      hex = hex
+        .split('')
+        .map((char) => `${char}${char}`)
+        .join('');
+    }
+
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+
+    return `linear-gradient(90deg, rgba(${r}, ${g}, ${b}, 1) 0%, rgba(${r}, ${g}, ${b}, 0) 100%)`;
+  }
+
+  return `linear-gradient(90deg, ${sourceColor} 0%, transparent 100%)`;
 };
 
 export const MealPlannerPage = ({
@@ -121,6 +147,10 @@ export const MealPlannerPage = ({
         <div className="grid grid--responsive">
           {mealGroups.map((group) => (
             <Card key={group.id} className="meal-group-card">
+              <div
+                className="meal-group-card__accent"
+                style={{ background: createAccentGradient(group.accentColor) }}
+              />
               <CardHeader
                 title={group.name}
                 subtitle={group.description}
@@ -144,7 +174,6 @@ export const MealPlannerPage = ({
               />
 
               <CardContent>
-                <div className="meal-group-card__accent" style={{ background: group.accentColor }} />
                 {group.dishes?.length ? (
                   <ul className="chip-list">
                     {group.dishes.map((dish) => (


### PR DESCRIPTION
## Summary
- convert meal group accents into gradients derived from their configured color
- reposition the accent element along the left edge of meal planner cards and layer card content above it

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e005f5c2b083308be819900caccf22