### PR TITLE
Enable dish creation to manage ingredients and group assignments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -151,6 +151,16 @@
   gap: var(--space-2xs);
 }
 
+.group-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+}
+
+.group-selector .form-field__input {
+  min-width: 220px;
+}
+
 .product-card__dishes {
   display: grid;
   gap: var(--space-sm);

--- a/src/App.js
+++ b/src/App.js
@@ -51,12 +51,15 @@ function App() {
           <DishesPage
             dishes={planner.dishes}
             products={planner.products}
+            mealGroups={planner.mealGroups}
             createDish={planner.createDish}
             updateDish={planner.updateDish}
             deleteDish={planner.deleteDish}
             createDishProduct={planner.createDishProduct}
             updateDishProduct={planner.updateDishProduct}
             deleteDishProduct={planner.deleteDishProduct}
+            createMealGroupDish={planner.createMealGroupDish}
+            deleteMealGroupDish={planner.deleteMealGroupDish}
             isMutating={planner.isMutating}
           />
         );

--- a/src/hooks/usePlannerData.js
+++ b/src/hooks/usePlannerData.js
@@ -107,8 +107,9 @@ export const usePlannerData = () => {
       setIsMutating(true);
 
       try {
-        await mutation();
+        const result = await mutation();
         await Promise.all(refreshers.map((ref) => ref()));
+        return result;
       } catch (err) {
         throw handleError(err);
       } finally {
@@ -131,61 +132,61 @@ export const usePlannerData = () => {
       refresh: loadAll,
       clearError,
       async createDish(payload) {
-        await runMutation(() => dishesApi.createDish(payload), [loadDishes]);
+        return runMutation(() => dishesApi.createDish(payload), [loadDishes]);
       },
       async updateDish(id, payload) {
-        await runMutation(() => dishesApi.updateDish(id, payload), [loadDishes]);
+        return runMutation(() => dishesApi.updateDish(id, payload), [loadDishes]);
       },
       async deleteDish(id) {
-        await runMutation(() => dishesApi.deleteDish(id), [loadDishes, loadMealGroups, loadDishProducts]);
+        return runMutation(() => dishesApi.deleteDish(id), [loadDishes, loadMealGroups, loadDishProducts]);
       },
       async createProduct(payload) {
-        await runMutation(() => productsApi.createProduct(payload), [loadProducts]);
+        return runMutation(() => productsApi.createProduct(payload), [loadProducts]);
       },
       async updateProduct(id, payload) {
-        await runMutation(() => productsApi.updateProduct(id, payload), [loadProducts]);
+        return runMutation(() => productsApi.updateProduct(id, payload), [loadProducts]);
       },
       async deleteProduct(id) {
-        await runMutation(() => productsApi.deleteProduct(id), [loadProducts, loadDishes, loadDishProducts]);
+        return runMutation(() => productsApi.deleteProduct(id), [loadProducts, loadDishes, loadDishProducts]);
       },
       async createMealGroup(payload) {
-        await runMutation(() => mealGroupsApi.createMealGroup(payload), [loadMealGroups]);
+        return runMutation(() => mealGroupsApi.createMealGroup(payload), [loadMealGroups]);
       },
       async updateMealGroup(id, payload) {
-        await runMutation(() => mealGroupsApi.updateMealGroup(id, payload), [loadMealGroups]);
+        return runMutation(() => mealGroupsApi.updateMealGroup(id, payload), [loadMealGroups]);
       },
       async deleteMealGroup(id) {
-        await runMutation(() => mealGroupsApi.deleteMealGroup(id), [loadMealGroups, loadMealGroupDishes]);
+        return runMutation(() => mealGroupsApi.deleteMealGroup(id), [loadMealGroups, loadMealGroupDishes]);
       },
       async createDishProduct(payload) {
-        await runMutation(() => dishProductsApi.createDishProduct(payload), [loadDishProducts, loadDishes]);
+        return runMutation(() => dishProductsApi.createDishProduct(payload), [loadDishProducts, loadDishes]);
       },
       async updateDishProduct(dishId, productId, payload) {
-        await runMutation(
+        return runMutation(
           () => dishProductsApi.updateDishProduct(dishId, productId, payload),
           [loadDishProducts, loadDishes],
         );
       },
       async deleteDishProduct(dishId, productId) {
-        await runMutation(
+        return runMutation(
           () => dishProductsApi.deleteDishProduct(dishId, productId),
           [loadDishProducts, loadDishes],
         );
       },
       async createMealGroupDish(payload) {
-        await runMutation(
+        return runMutation(
           () => mealGroupDishesApi.createMealGroupDish(payload),
           [loadMealGroupDishes, loadMealGroups, loadDishes],
         );
       },
       async updateMealGroupDish(mealGroupId, dishId, payload) {
-        await runMutation(
+        return runMutation(
           () => mealGroupDishesApi.updateMealGroupDish(mealGroupId, dishId, payload),
           [loadMealGroupDishes, loadMealGroups, loadDishes],
         );
       },
       async deleteMealGroupDish(mealGroupId, dishId) {
-        await runMutation(
+        return runMutation(
           () => mealGroupDishesApi.deleteMealGroupDish(mealGroupId, dishId),
           [loadMealGroupDishes, loadMealGroups, loadDishes],
         );


### PR DESCRIPTION
## Summary
- allow creating dishes with ingredient drafts and group selection directly in the dish modal
- return mutation results so the dish page can add ingredients/groups after creation and pass through the meal-group APIs
- add styling for the new group selector layout

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e00f2dddb48330b08effc386202a7d