### PR TITLE
Add meal group detail view and streamlined cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -132,8 +132,10 @@
 
 .dish-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   gap: var(--space-md);
+  max-width: calc(2 * 420px + var(--space-md));
+  margin: 0 auto;
 }
 
 .dish-card {

--- a/src/App.css
+++ b/src/App.css
@@ -113,6 +113,36 @@
   opacity: 0.6;
 }
 
+.dish-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+.dish-card {
+  padding: var(--space-md);
+  gap: var(--space-sm);
+}
+
+.dish-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.dish-card__title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.dish-card__name {
+  margin: 0;
+  font-weight: 700;
+  color: var(--color-text-strong);
+}
+
 .dish-card__info {
   display: grid;
   gap: var(--space-sm);

--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,7 @@
 }
 
 .grid--responsive {
-  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr));
 }
 
 .stack {

--- a/src/App.css
+++ b/src/App.css
@@ -44,6 +44,23 @@
   font-size: 1.05rem;
 }
 
+.section {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.section-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.section-heading__title {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-text-strong);
+}
+
 .card-action-buttons {
   display: flex;
   gap: var(--space-xs);

--- a/src/App.css
+++ b/src/App.css
@@ -50,6 +50,12 @@
   flex-wrap: wrap;
 }
 
+.icon-button {
+  padding: var(--space-3xs) var(--space-xs);
+  min-width: auto;
+  line-height: 1;
+}
+
 .muted {
   color: var(--color-muted);
   margin: 0;
@@ -60,28 +66,51 @@
   margin: 0;
 }
 
-.meal-group-card {
-  position: relative;
-  overflow: hidden;
+
+.chip-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
 }
 
-.meal-group-card__accent {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 5px;
-  border-radius: var(--radius-2xl);
-  pointer-events: none;
-  z-index: 0;
-  background-color: #ff7e5f;
+.chip-list--spacious {
+  gap: var(--space-xs);
 }
 
-.meal-group-card .card__header,
-.meal-group-card .card__content,
-.meal-group-card .card__footer {
-  position: relative;
-  z-index: 1;
+.chip-list__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3xs);
+  padding: var(--space-3xs) var(--space-2xs) var(--space-3xs) var(--space-xs);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.chip-list__remove {
+  border: none;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--color-text-strong);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.chip-list__remove:hover:not(:disabled) {
+  background: rgba(15, 23, 42, 0.1);
+}
+
+.chip-list__remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .dish-card__info {
@@ -192,6 +221,35 @@
 
 .alert__action {
   margin-left: var(--space-sm);
+}
+
+.page__breadcrumbs {
+  display: grid;
+  gap: var(--space-3xs);
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--color-primary-strong);
+  font-weight: 600;
+  padding: 0;
+  cursor: pointer;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.modal-actions__end {
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+  flex: 1;
 }
 
 @media (min-width: 768px) {

--- a/src/App.css
+++ b/src/App.css
@@ -132,9 +132,10 @@
 
 .dish-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-  gap: var(--space-md);
-  max-width: calc(2 * 420px + var(--space-md));
+  grid-template-columns: repeat(auto-fit, minmax(min(460px, 100%), 1fr));
+  gap: var(--space-lg);
+  max-width: min(calc(2 * 520px + var(--space-lg)), 100%);
+  width: 100%;
   margin: 0 auto;
 }
 

--- a/src/components/common/Card.css
+++ b/src/components/common/Card.css
@@ -7,10 +7,38 @@
   flex-direction: column;
   gap: var(--space-md);
   border: 1px solid rgba(15, 23, 42, 0.05);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  position: relative;
+  overflow: hidden;
 }
 
 .card--muted {
   background: rgba(255, 255, 255, 0.7);
+}
+
+.card--accented {
+  border-color: color-mix(in srgb, var(--card-accent-color, #ff7e5f) 25%, rgba(15, 23, 42, 0.08));
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+}
+
+.card--accented::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(15, 23, 42, 0.03);
+  background: linear-gradient(
+    120deg,
+    color-mix(in srgb, var(--card-accent-color, #ff7e5f) 14%, transparent),
+    transparent 40%,
+    transparent
+  );
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
 }
 
 .card__header {
@@ -18,6 +46,20 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-md);
+}
+
+.card__title-group {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.card__accent {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.04);
+  border: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .card__title {

--- a/src/components/common/Card.js
+++ b/src/components/common/Card.js
@@ -1,16 +1,23 @@
 import './Card.css';
 
-export const Card = ({ tone = 'default', children, className = '', ...props }) => (
-  <section className={`card card--${tone} ${className}`.trim()} {...props}>
+export const Card = ({ tone = 'default', children, className = '', accentColor, ...props }) => (
+  <section
+    className={`card card--${tone} ${accentColor ? 'card--accented' : ''} ${className}`.trim()}
+    style={accentColor ? { '--card-accent-color': accentColor } : undefined}
+    {...props}
+  >
     {children}
   </section>
 );
 
-export const CardHeader = ({ title, subtitle, endSlot }) => (
+export const CardHeader = ({ title, subtitle, endSlot, accentColor }) => (
   <header className="card__header">
-    <div>
-      <h2 className="card__title">{title}</h2>
-      {subtitle && <p className="card__subtitle">{subtitle}</p>}
+    <div className="card__title-group">
+      {accentColor && <span className="card__accent" aria-hidden style={{ backgroundColor: accentColor }} />}
+      <div>
+        <h2 className="card__title">{title}</h2>
+        {subtitle && <p className="card__subtitle">{subtitle}</p>}
+      </div>
     </div>
     {endSlot && <div className="card__header-actions">{endSlot}</div>}
   </header>

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Card, CardContent, CardHeader } from '../components/common/Card';
+import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { Modal } from '../components/common/Modal';
 import { EmptyState } from '../components/common/EmptyState';
@@ -66,48 +66,60 @@ export const MealGroupDetailPage = ({
         <Button onClick={openAssignDishModal}>Добавить блюдо</Button>
       </div>
 
-      <Card accentColor={mealGroup.accentColor}>
-        <CardHeader title="Блюда в наборе" accentColor={mealGroup.accentColor} />
-
-        <CardContent>
-          {mealGroup.dishes?.length ? (
-            <div className="dish-grid">
-              {mealGroup.dishes.map((dish) => (
-                <Card key={dish.dishId} className="dish-card" accentColor={mealGroup.accentColor}>
-                  <div className="dish-card__header">
-                    <div className="dish-card__title">
-                      {mealGroup.accentColor && (
-                        <span
-                          className="card__accent"
-                          aria-hidden
-                          style={{ backgroundColor: mealGroup.accentColor }}
-                        />
-                      )}
-                      <p className="dish-card__name">{dish.dishName}</p>
-                    </div>
-
-                    <Button
-                      variant="ghost"
-                      className="icon-button"
-                      onClick={() => deleteMealGroupDish(mealGroup.id, dish.dishId)}
-                      disabled={isMutating}
-                      aria-label={`Убрать блюдо ${dish.dishName}`}
-                    >
-                      ×
-                    </Button>
-                  </div>
-                </Card>
-              ))}
+      <div className="section">
+        <div className="section-header">
+          <div className="section-heading">
+            {mealGroup.accentColor && (
+              <span
+                className="card__accent"
+                aria-hidden
+                style={{ backgroundColor: mealGroup.accentColor }}
+              />
+            )}
+            <div>
+              <h3 className="section-heading__title">Блюда в наборе</h3>
+              <p className="muted">Каждое блюдо представлено отдельной карточкой.</p>
             </div>
-          ) : (
-            <EmptyState
-              title="Блюд пока нет"
-              description="Добавьте первые блюда в этот набор, чтобы перейти к планированию."
-              action={<Button onClick={openAssignDishModal}>Добавить блюдо</Button>}
-            />
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        </div>
+
+        {mealGroup.dishes?.length ? (
+          <div className="dish-grid">
+            {mealGroup.dishes.map((dish) => (
+              <Card key={dish.dishId} className="dish-card" accentColor={mealGroup.accentColor}>
+                <div className="dish-card__header">
+                  <div className="dish-card__title">
+                    {mealGroup.accentColor && (
+                      <span
+                        className="card__accent"
+                        aria-hidden
+                        style={{ backgroundColor: mealGroup.accentColor }}
+                      />
+                    )}
+                    <p className="dish-card__name">{dish.dishName}</p>
+                  </div>
+
+                  <Button
+                    variant="ghost"
+                    className="icon-button"
+                    onClick={() => deleteMealGroupDish(mealGroup.id, dish.dishId)}
+                    disabled={isMutating}
+                    aria-label={`Убрать блюдо ${dish.dishName}`}
+                  >
+                    ×
+                  </Button>
+                </div>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <EmptyState
+            title="Блюд пока нет"
+            description="Добавьте первые блюда в этот набор, чтобы перейти к планированию."
+            action={<Button onClick={openAssignDishModal}>Добавить блюдо</Button>}
+          />
+        )}
+      </div>
 
       <Modal
         open={isAssignModalOpen}

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -1,0 +1,128 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader } from '../components/common/Card';
+import { Button } from '../components/common/Button';
+import { Modal } from '../components/common/Modal';
+import { EmptyState } from '../components/common/EmptyState';
+import { FormField, SelectInput } from '../components/forms/FormField';
+import { Tag } from '../components/common/Tag';
+
+export const MealGroupDetailPage = ({
+  mealGroup,
+  dishes,
+  onBack,
+  createMealGroupDish,
+  deleteMealGroupDish,
+  isMutating,
+}) => {
+  const [isAssignModalOpen, setAssignModalOpen] = useState(false);
+  const [selectedDishId, setSelectedDishId] = useState('');
+
+  const dishOptions = useMemo(
+    () => dishes.map((dish) => ({ label: dish.name, value: String(dish.id) })),
+    [dishes],
+  );
+
+  const selectedGroupDishIds = mealGroup?.dishes?.map((item) => item.dishId) ?? [];
+  const filteredDishOptions = dishOptions.filter((option) => !selectedGroupDishIds.includes(Number(option.value)));
+
+  const openAssignDishModal = () => {
+    setSelectedDishId('');
+    setAssignModalOpen(true);
+  };
+
+  const submitAssignDish = async () => {
+    if (!selectedDishId || !mealGroup) return;
+
+    await createMealGroupDish({ mealGroupId: mealGroup.id, dishId: Number(selectedDishId) });
+    setAssignModalOpen(false);
+  };
+
+  if (!mealGroup) {
+    return (
+      <EmptyState
+        title="Набор не найден"
+        description="Вернитесь на предыдущую страницу и выберите другой набор."
+        action={
+          onBack && (
+            <Button variant="ghost" onClick={onBack}>
+              Назад
+            </Button>
+          )
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="page">
+      <div className="page__header">
+        <div className="page__breadcrumbs">
+          <button type="button" className="link-button" onClick={onBack}>
+            ← Назад к наборам
+          </button>
+          <h2 className="page__title">{mealGroup.name}</h2>
+          {mealGroup.description && <p className="muted">{mealGroup.description}</p>}
+        </div>
+
+        <Button onClick={openAssignDishModal}>Добавить блюдо</Button>
+      </div>
+
+      <Card accentColor={mealGroup.accentColor}>
+        <CardHeader title="Блюда в наборе" accentColor={mealGroup.accentColor} />
+
+        <CardContent>
+          {mealGroup.dishes?.length ? (
+            <ul className="chip-list chip-list--spacious">
+              {mealGroup.dishes.map((dish) => (
+                <li key={dish.dishId} className="chip-list__item">
+                  <Tag tone="accent">{dish.dishName}</Tag>
+                  <button
+                    type="button"
+                    className="chip-list__remove"
+                    onClick={() => deleteMealGroupDish(mealGroup.id, dish.dishId)}
+                    disabled={isMutating}
+                    aria-label={`Убрать блюдо ${dish.dishName}`}
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState
+              title="Блюд пока нет"
+              description="Добавьте первые блюда в этот набор, чтобы перейти к планированию."
+              action={<Button onClick={openAssignDishModal}>Добавить блюдо</Button>}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Modal
+        open={isAssignModalOpen}
+        title="Добавить блюдо в набор"
+        onClose={() => setAssignModalOpen(false)}
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setAssignModalOpen(false)} disabled={isMutating}>
+              Отмена
+            </Button>
+            <Button onClick={submitAssignDish} disabled={!selectedDishId || isMutating}>
+              Добавить
+            </Button>
+          </>
+        }
+      >
+        <FormField label="Блюдо" hint="Можно добавить любое блюдо из списка">
+          <SelectInput
+            value={selectedDishId}
+            onChange={(event) => setSelectedDishId(event.target.value)}
+            options={filteredDishOptions}
+            placeholder={filteredDishOptions.length ? 'Выберите блюдо' : 'Все блюда уже добавлены'}
+            disabled={filteredDishOptions.length === 0}
+          />
+        </FormField>
+      </Modal>
+    </div>
+  );
+};

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -4,7 +4,6 @@ import { Button } from '../components/common/Button';
 import { Modal } from '../components/common/Modal';
 import { EmptyState } from '../components/common/EmptyState';
 import { FormField, SelectInput } from '../components/forms/FormField';
-import { Tag } from '../components/common/Tag';
 
 export const MealGroupDetailPage = ({
   mealGroup,
@@ -72,22 +71,34 @@ export const MealGroupDetailPage = ({
 
         <CardContent>
           {mealGroup.dishes?.length ? (
-            <ul className="chip-list chip-list--spacious">
+            <div className="dish-grid">
               {mealGroup.dishes.map((dish) => (
-                <li key={dish.dishId} className="chip-list__item">
-                  <Tag tone="accent">{dish.dishName}</Tag>
-                  <button
-                    type="button"
-                    className="chip-list__remove"
-                    onClick={() => deleteMealGroupDish(mealGroup.id, dish.dishId)}
-                    disabled={isMutating}
-                    aria-label={`Убрать блюдо ${dish.dishName}`}
-                  >
-                    ×
-                  </button>
-                </li>
+                <Card key={dish.dishId} className="dish-card" accentColor={mealGroup.accentColor}>
+                  <div className="dish-card__header">
+                    <div className="dish-card__title">
+                      {mealGroup.accentColor && (
+                        <span
+                          className="card__accent"
+                          aria-hidden
+                          style={{ backgroundColor: mealGroup.accentColor }}
+                        />
+                      )}
+                      <p className="dish-card__name">{dish.dishName}</p>
+                    </div>
+
+                    <Button
+                      variant="ghost"
+                      className="icon-button"
+                      onClick={() => deleteMealGroupDish(mealGroup.id, dish.dishId)}
+                      disabled={isMutating}
+                      aria-label={`Убрать блюдо ${dish.dishName}`}
+                    >
+                      ×
+                    </Button>
+                  </div>
+                </Card>
               ))}
-            </ul>
+            </div>
           ) : (
             <EmptyState
               title="Блюд пока нет"


### PR DESCRIPTION
## Summary
- simplify meal group cards to focus on accent color, title, and subtitle with a settings control
- add a dedicated meal group detail page for managing dishes within a group
- enhance styling for cards, chips, and modal actions to match the new flow

## Testing
- CI=true npm test -- --watch=false
