### PR TITLE
Improve meal group dish search

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -287,6 +287,64 @@
   cursor: pointer;
 }
 
+.searchable-select {
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.searchable-select__input {
+  width: 100%;
+}
+
+.searchable-select__list {
+  display: grid;
+  gap: var(--space-2xs);
+  max-height: 260px;
+  overflow-y: auto;
+  padding: var(--space-2xs);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+}
+
+.searchable-select__option {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.6);
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-xs);
+  transition: border 120ms ease, box-shadow 120ms ease, transform 120ms ease, background 120ms ease;
+}
+
+.searchable-select__option:hover {
+  background: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+.searchable-select__option--active {
+  border-color: rgba(255, 126, 95, 0.5);
+  box-shadow: 0 0 0 3px rgba(255, 126, 95, 0.15);
+}
+
+.searchable-select__option-title {
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+
+.searchable-select__check {
+  font-size: 0.85rem;
+  color: var(--color-primary-strong);
+  font-weight: 700;
+}
+
 .modal-actions {
   display: flex;
   justify-content: space-between;

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -3,7 +3,7 @@ import { Card } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { Modal } from '../components/common/Modal';
 import { EmptyState } from '../components/common/EmptyState';
-import { FormField, SelectInput } from '../components/forms/FormField';
+import { FormField } from '../components/forms/FormField';
 
 export const MealGroupDetailPage = ({
   mealGroup,
@@ -15,6 +15,7 @@ export const MealGroupDetailPage = ({
 }) => {
   const [isAssignModalOpen, setAssignModalOpen] = useState(false);
   const [selectedDishId, setSelectedDishId] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
 
   const dishOptions = useMemo(
     () => dishes.map((dish) => ({ label: dish.name, value: String(dish.id) })),
@@ -22,10 +23,21 @@ export const MealGroupDetailPage = ({
   );
 
   const selectedGroupDishIds = mealGroup?.dishes?.map((item) => item.dishId) ?? [];
-  const filteredDishOptions = dishOptions.filter((option) => !selectedGroupDishIds.includes(Number(option.value)));
+  const availableDishOptions = useMemo(
+    () => dishOptions.filter((option) => !selectedGroupDishIds.includes(Number(option.value))),
+    [dishOptions, selectedGroupDishIds],
+  );
+
+  const filteredDishOptions = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    if (!query) return availableDishOptions;
+
+    return availableDishOptions.filter((option) => option.label.toLowerCase().includes(query));
+  }, [availableDishOptions, searchTerm]);
 
   const openAssignDishModal = () => {
     setSelectedDishId('');
+    setSearchTerm('');
     setAssignModalOpen(true);
   };
 
@@ -136,14 +148,43 @@ export const MealGroupDetailPage = ({
           </>
         }
       >
-        <FormField label="Блюдо" hint="Можно добавить любое блюдо из списка">
-          <SelectInput
-            value={selectedDishId}
-            onChange={(event) => setSelectedDishId(event.target.value)}
-            options={filteredDishOptions}
-            placeholder={filteredDishOptions.length ? 'Выберите блюдо' : 'Все блюда уже добавлены'}
-            disabled={filteredDishOptions.length === 0}
-          />
+        <FormField label="Блюдо" hint="Найдите и добавьте любое блюдо из коллекции">
+          <div className="searchable-select">
+            <input
+              type="search"
+              className="form-field__input searchable-select__input"
+              placeholder={availableDishOptions.length ? 'Введите название блюда' : 'Все блюда уже добавлены'}
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              disabled={availableDishOptions.length === 0}
+            />
+
+            <div className="searchable-select__list" role="list">
+              {availableDishOptions.length === 0 && (
+                <p className="muted" role="status">
+                  Все блюда уже добавлены в этот набор.
+                </p>
+              )}
+
+              {availableDishOptions.length > 0 && filteredDishOptions.length === 0 && (
+                <p className="muted" role="status">
+                  Ничего не найдено. Попробуйте изменить запрос.
+                </p>
+              )}
+
+              {filteredDishOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`searchable-select__option ${selectedDishId === option.value ? 'searchable-select__option--active' : ''}`}
+                  onClick={() => setSelectedDishId(option.value)}
+                >
+                  <span className="searchable-select__option-title">{option.label}</span>
+                  {selectedDishId === option.value && <span className="searchable-select__check">Добавлено</span>}
+                </button>
+              ))}
+            </div>
+          </div>
         </FormField>
       </Modal>
     </div>

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -16,6 +16,7 @@ export const MealGroupDetailPage = ({
   const [isAssignModalOpen, setAssignModalOpen] = useState(false);
   const [selectedDishId, setSelectedDishId] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
+  const [isDishListOpen, setDishListOpen] = useState(false);
 
   const dishOptions = useMemo(
     () => dishes.map((dish) => ({ label: dish.name, value: String(dish.id) })),
@@ -38,6 +39,7 @@ export const MealGroupDetailPage = ({
   const openAssignDishModal = () => {
     setSelectedDishId('');
     setSearchTerm('');
+    setDishListOpen(false);
     setAssignModalOpen(true);
   };
 
@@ -149,41 +151,55 @@ export const MealGroupDetailPage = ({
         }
       >
         <FormField label="Блюдо" hint="Найдите и добавьте любое блюдо из коллекции">
-          <div className="searchable-select">
+          <div
+            className="searchable-select"
+            onBlur={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget)) {
+                setDishListOpen(false);
+              }
+            }}
+          >
             <input
               type="search"
               className="form-field__input searchable-select__input"
               placeholder={availableDishOptions.length ? 'Введите название блюда' : 'Все блюда уже добавлены'}
               value={searchTerm}
               onChange={(event) => setSearchTerm(event.target.value)}
+              onFocus={() => availableDishOptions.length && setDishListOpen(true)}
+              onClick={() => availableDishOptions.length && setDishListOpen(true)}
               disabled={availableDishOptions.length === 0}
             />
 
-            <div className="searchable-select__list" role="list">
-              {availableDishOptions.length === 0 && (
-                <p className="muted" role="status">
-                  Все блюда уже добавлены в этот набор.
-                </p>
-              )}
+            {isDishListOpen && (
+              <div className="searchable-select__list" role="list">
+                {availableDishOptions.length === 0 && (
+                  <p className="muted" role="status">
+                    Все блюда уже добавлены в этот набор.
+                  </p>
+                )}
 
-              {availableDishOptions.length > 0 && filteredDishOptions.length === 0 && (
-                <p className="muted" role="status">
-                  Ничего не найдено. Попробуйте изменить запрос.
-                </p>
-              )}
+                {availableDishOptions.length > 0 && filteredDishOptions.length === 0 && (
+                  <p className="muted" role="status">
+                    Ничего не найдено. Попробуйте изменить запрос.
+                  </p>
+                )}
 
-              {filteredDishOptions.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  className={`searchable-select__option ${selectedDishId === option.value ? 'searchable-select__option--active' : ''}`}
-                  onClick={() => setSelectedDishId(option.value)}
-                >
-                  <span className="searchable-select__option-title">{option.label}</span>
-                  {selectedDishId === option.value && <span className="searchable-select__check">Добавлено</span>}
-                </button>
-              ))}
-            </div>
+                {filteredDishOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`searchable-select__option ${selectedDishId === option.value ? 'searchable-select__option--active' : ''}`}
+                    onClick={() => {
+                      setSelectedDishId(option.value);
+                      setDishListOpen(false);
+                    }}
+                  >
+                    <span className="searchable-select__option-title">{option.label}</span>
+                    {selectedDishId === option.value && <span className="searchable-select__check">Добавлено</span>}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </FormField>
       </Modal>


### PR DESCRIPTION
## Summary
- replace the dish dropdown in the meal group modal with a searchable list and clearer empty states
- add styling for the new searchable selector with hover and active cues

## Testing
- CI=true npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505362af008330bcb19e9fe09a45e4)