### PR TITLE
Fix back link spacing on meal group detail

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -285,6 +285,14 @@
   font-weight: 600;
   padding: 0;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3xs);
+  text-align: left;
+}
+
+.page__breadcrumbs .link-button {
+  justify-self: start;
 }
 
 .searchable-select {

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -70,9 +70,7 @@ export const MealGroupDetailPage = ({
     <div className="page">
       <div className="page__header">
         <div className="page__breadcrumbs">
-          <button type="button" className="link-button" onClick={onBack}>
-            ← Назад к наборам
-          </button>
+          <button type="button" className="link-button" onClick={onBack}>← Назад к наборам</button>
           <h2 className="page__title">{mealGroup.name}</h2>
           {mealGroup.description && <p className="muted">{mealGroup.description}</p>}
         </div>


### PR DESCRIPTION
## Summary
- remove unintended leading whitespace on the "Назад к наборам" button text so it aligns flush to the left

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950588006748330a77c7f5611c4110f)