### PR TITLE
Add dish detail view and update dish cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -142,6 +142,8 @@
 .dish-card {
   padding: var(--space-md);
   gap: var(--space-sm);
+  cursor: pointer;
+  position: relative;
 }
 
 .dish-card__header {
@@ -161,6 +163,51 @@
   margin: 0;
   font-weight: 700;
   color: var(--color-text-strong);
+}
+
+.dish-card__actions {
+  position: relative;
+  display: inline-flex;
+}
+
+.dish-card__menu {
+  position: absolute;
+  top: calc(100% + var(--space-2xs));
+  right: 0;
+  display: grid;
+  gap: var(--space-3xs);
+  padding: var(--space-xs);
+  background: white;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  min-width: 180px;
+  z-index: 1;
+}
+
+.dish-card__menu-item {
+  border: none;
+  background: transparent;
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-strong);
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.dish-card__menu-item:hover,
+.dish-card__menu-item:focus-visible {
+  background: rgba(255, 126, 95, 0.12);
+}
+
+.dish-card__menu-item--danger {
+  color: rgb(185, 28, 28);
+}
+
+.dish-card__menu-item--danger:hover,
+.dish-card__menu-item--danger:focus-visible {
+  background: rgba(248, 113, 113, 0.12);
 }
 
 .dish-card__info {
@@ -366,6 +413,32 @@
   gap: var(--space-xs);
   justify-content: flex-end;
   flex: 1;
+}
+
+.dish-detail__layout {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.dish-detail__main {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.dish-detail__sidebar {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.dish-detail__section {
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+@media (min-width: 900px) {
+  .dish-detail__layout {
+    grid-template-columns: 2fr 1fr;
+  }
 }
 
 @media (min-width: 768px) {

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { usePlannerData } from './hooks/usePlannerData';
 import { MealPlannerPage } from './pages/MealPlannerPage';
 import { MealGroupDetailPage } from './pages/MealGroupDetailPage';
 import { DishesPage } from './pages/DishesPage';
+import { DishDetailPage } from './pages/DishDetailPage';
 import { ProductsPage } from './pages/ProductsPage';
 import { Alert } from './components/common/Alert';
 import { Button } from './components/common/Button';
@@ -26,6 +27,10 @@ const VIEW_CONFIG = {
     title: 'Набор приёмов пищи',
     subtitle: 'MealMate',
   },
+  dishDetail: {
+    title: 'Блюдо',
+    subtitle: 'MealMate',
+  },
 };
 
 const NAV_ITEMS = [
@@ -37,18 +42,28 @@ const NAV_ITEMS = [
 function App() {
   const [view, setView] = useState('planner');
   const [activeGroupId, setActiveGroupId] = useState(null);
+  const [activeDishId, setActiveDishId] = useState(null);
   const planner = usePlannerData();
 
   const activeGroup = planner.mealGroups.find((group) => group.id === activeGroupId);
+  const activeDish = planner.dishes.find((dish) => dish.id === activeDishId);
 
-  const { title, subtitle } =
-    view === 'groupDetail' && activeGroup
-      ? { title: activeGroup.name, subtitle: 'Набор приёмов пищи' }
-      : VIEW_CONFIG[view] ?? VIEW_CONFIG.planner;
+  const { title, subtitle } = (() => {
+    if (view === 'groupDetail' && activeGroup) {
+      return { title: activeGroup.name, subtitle: 'Набор приёмов пищи' };
+    }
+
+    if (view === 'dishDetail' && activeDish) {
+      return { title: activeDish.name, subtitle: 'Блюдо' };
+    }
+
+    return VIEW_CONFIG[view] ?? VIEW_CONFIG.planner;
+  })();
 
   const changeView = (nextView) => {
     setView(nextView);
     setActiveGroupId(null);
+    setActiveDishId(null);
   };
 
   const content = useMemo(() => {
@@ -77,6 +92,10 @@ function App() {
             createMealGroupDish={planner.createMealGroupDish}
             deleteMealGroupDish={planner.deleteMealGroupDish}
             isMutating={planner.isMutating}
+            onOpenDish={(dishId) => {
+              setActiveDishId(dishId);
+              setView('dishDetail');
+            }}
           />
         );
       case 'products':
@@ -115,12 +134,14 @@ function App() {
             onBack={() => setView('planner')}
           />
         );
+      case 'dishDetail':
+        return <DishDetailPage dish={activeDish} onBack={() => setView('dishes')} />;
     }
-  }, [activeGroup, planner, view]);
+  }, [activeDish, activeGroup, planner, view]);
 
   return (
     <AppLayout
-      activeView={view === 'groupDetail' ? 'planner' : view}
+      activeView={view === 'groupDetail' ? 'planner' : view === 'dishDetail' ? 'dishes' : view}
       onChangeView={changeView}
       title={title}
       subtitle={subtitle}

--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,7 @@ function App() {
   const [view, setView] = useState('planner');
   const [activeGroupId, setActiveGroupId] = useState(null);
   const [activeDishId, setActiveDishId] = useState(null);
+  const [pendingDishEditId, setPendingDishEditId] = useState(null);
   const planner = usePlannerData();
 
   const activeGroup = planner.mealGroups.find((group) => group.id === activeGroupId);
@@ -92,6 +93,8 @@ function App() {
             createMealGroupDish={planner.createMealGroupDish}
             deleteMealGroupDish={planner.deleteMealGroupDish}
             isMutating={planner.isMutating}
+            editingDishId={pendingDishEditId}
+            onEditingDishHandled={() => setPendingDishEditId(null)}
             onOpenDish={(dishId) => {
               setActiveDishId(dishId);
               setView('dishDetail');
@@ -135,7 +138,21 @@ function App() {
           />
         );
       case 'dishDetail':
-        return <DishDetailPage dish={activeDish} onBack={() => setView('dishes')} />;
+        return (
+          <DishDetailPage
+            dish={activeDish}
+            onBack={() => setView('dishes')}
+            onEditDish={(dishId) => {
+              setPendingDishEditId(dishId);
+              setView('dishes');
+            }}
+            onDeleteDish={async (dishId) => {
+              await planner.deleteDish(dishId);
+              setView('dishes');
+            }}
+            isMutating={planner.isMutating}
+          />
+        );
     }
   }, [activeDish, activeGroup, planner, view]);
 

--- a/src/pages/DishDetailPage.js
+++ b/src/pages/DishDetailPage.js
@@ -1,0 +1,91 @@
+import { Card, CardContent } from '../components/common/Card';
+import { Tag } from '../components/common/Tag';
+import { EmptyState } from '../components/common/EmptyState';
+import { Button } from '../components/common/Button';
+
+export const DishDetailPage = ({ dish, onBack }) => {
+  if (!dish) {
+    return (
+      <EmptyState
+        title="Блюдо не найдено"
+        description="Вернитесь назад и выберите другое блюдо из коллекции."
+        action={
+          onBack && (
+            <Button variant="ghost" onClick={onBack}>
+              Назад к блюдам
+            </Button>
+          )
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="page">
+      <div className="page__header">
+        <div className="page__breadcrumbs">
+          <button type="button" className="link-button" onClick={onBack}>
+            ← Назад к блюдам
+          </button>
+          <h2 className="page__title">{dish.name}</h2>
+          {dish.description && <p className="muted">{dish.description}</p>}
+        </div>
+      </div>
+
+      <Card className="dish-detail">
+        <CardContent>
+          <div className="dish-detail__layout">
+            <div className="dish-detail__main">
+              <div className="dish-detail__section">
+                <h3 className="section-heading__title">Описание</h3>
+                {dish.description ? (
+                  <p className="multiline">{dish.description}</p>
+                ) : (
+                  <p className="muted">Описание не указано</p>
+                )}
+              </div>
+
+              <div className="dish-detail__section">
+                <h3 className="section-heading__title">Инструкции</h3>
+                {dish.instructions ? (
+                  <p className="multiline">{dish.instructions}</p>
+                ) : (
+                  <p className="muted">Инструкции отсутствуют</p>
+                )}
+              </div>
+            </div>
+
+            <div className="dish-detail__sidebar">
+              <div className="dish-detail__section">
+                <h3 className="section-heading__title">Время приготовления</h3>
+                {dish.preparationMinutes ? (
+                  <span className="dish-card__meta-time">{dish.preparationMinutes} мин.</span>
+                ) : (
+                  <p className="muted">Не указано</p>
+                )}
+              </div>
+
+              <div className="dish-detail__section">
+                <h3 className="section-heading__title">Ингредиенты</h3>
+                {dish.products?.length ? (
+                  <div className="ingredient-tag-list">
+                    {dish.products.map((product) => (
+                      <Tag key={product.productId}>
+                        <span className="ingredient-tag__name">{product.productName}</span>
+                        {product.quantity && (
+                          <span className="ingredient-tag__quantity">{product.quantity}</span>
+                        )}
+                      </Tag>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="muted">Ингредиенты ещё не добавлены</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/pages/DishDetailPage.js
+++ b/src/pages/DishDetailPage.js
@@ -1,9 +1,16 @@
+import { useEffect, useState } from 'react';
 import { Card, CardContent } from '../components/common/Card';
 import { Tag } from '../components/common/Tag';
 import { EmptyState } from '../components/common/EmptyState';
 import { Button } from '../components/common/Button';
 
-export const DishDetailPage = ({ dish, onBack }) => {
+export const DishDetailPage = ({ dish, onBack, onEditDish, onDeleteDish, isMutating }) => {
+  const [isMenuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [dish?.id]);
+
   if (!dish) {
     return (
       <EmptyState
@@ -29,6 +36,48 @@ export const DishDetailPage = ({ dish, onBack }) => {
           </button>
           <h2 className="page__title">{dish.name}</h2>
           {dish.description && <p className="muted">{dish.description}</p>}
+        </div>
+
+        <div className="dish-card__actions">
+          <Button
+            variant="ghost"
+            className="icon-button"
+            aria-label={`Действия с блюдом ${dish.name}`}
+            onClick={() => setMenuOpen((state) => !state)}
+          >
+            ⚙️
+          </Button>
+
+          {isMenuOpen && (
+            <div className="dish-card__menu" role="menu">
+              <button
+                type="button"
+                className="dish-card__menu-item"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onEditDish?.(dish.id);
+                }}
+              >
+                Редактировать
+              </button>
+              <button
+                type="button"
+                className="dish-card__menu-item dish-card__menu-item--danger"
+                disabled={isMutating}
+                onClick={() => {
+                  setMenuOpen(false);
+                  if (!onDeleteDish) return;
+
+                  const shouldDelete = window.confirm('Удалить это блюдо?');
+                  if (shouldDelete) {
+                    onDeleteDish(dish.id);
+                  }
+                }}
+              >
+                Удалить
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/pages/DishesPage.js
+++ b/src/pages/DishesPage.js
@@ -34,6 +34,8 @@ export const DishesPage = ({
   createMealGroupDish,
   deleteMealGroupDish,
   isMutating,
+  editingDishId,
+  onEditingDishHandled,
   onOpenDish,
 }) => {
   const [isDishModalOpen, setDishModalOpen] = useState(false);
@@ -81,6 +83,22 @@ export const DishesPage = ({
 
     return map;
   }, [mealGroups]);
+
+  useEffect(() => {
+    if (!editingDishId) {
+      return;
+    }
+
+    const dishToEdit = dishes.find((dish) => dish.id === editingDishId);
+
+    if (!dishToEdit) {
+      onEditingDishHandled?.();
+      return;
+    }
+
+    openEditDishModal(dishToEdit);
+    onEditingDishHandled?.();
+  }, [dishes, editingDishId, onEditingDishHandled]);
 
   useEffect(() => {
     if (!editingDish) {

--- a/src/pages/DishesPage.js
+++ b/src/pages/DishesPage.js
@@ -34,6 +34,7 @@ export const DishesPage = ({
   createMealGroupDish,
   deleteMealGroupDish,
   isMutating,
+  onOpenDish,
 }) => {
   const [isDishModalOpen, setDishModalOpen] = useState(false);
   const [editingDish, setEditingDish] = useState(null);
@@ -46,6 +47,7 @@ export const DishesPage = ({
   const [isIngredientModalOpen, setIngredientModalOpen] = useState(false);
   const [ingredientForm, setIngredientForm] = useState(defaultIngredient);
   const [editingIngredient, setEditingIngredient] = useState(null);
+  const [openActionMenuId, setOpenActionMenuId] = useState(null);
 
   const productOptions = useMemo(
     () => products.map((product) => ({ label: product.name, value: String(product.id) })),
@@ -328,6 +330,12 @@ export const DishesPage = ({
   const disableIngredientActions = isExistingDish && isMutating;
   const disableGroupActions = isExistingDish && isMutating;
 
+  const toggleActionMenu = (dishId) => {
+    setOpenActionMenuId((current) => (current === dishId ? null : dishId));
+  };
+
+  const closeActionMenu = () => setOpenActionMenuId(null);
+
   return (
     <div className="page">
       <div className="page__header">
@@ -344,32 +352,61 @@ export const DishesPage = ({
       ) : (
         <div className="stack">
           {dishes.map((dish) => (
-            <Card key={dish.id} className="dish-card">
+            <Card
+              key={dish.id}
+              className="dish-card"
+              onClick={() => {
+                closeActionMenu();
+                onOpenDish?.(dish.id);
+              }}
+            >
               <CardHeader
                 title={dish.name}
-                subtitle={dish.description}
                 endSlot={
-                  <div className="card-action-buttons">
-                    <Button variant="ghost" onClick={() => openEditDishModal(dish)}>
-                      Редактировать
-                    </Button>
+                  <div className="dish-card__actions" onClick={(event) => event.stopPropagation()}>
                     <Button
-                      variant="danger"
-                      onClick={() => deleteDish(dish.id)}
-                      disabled={isMutating}
+                      variant="ghost"
+                      className="icon-button"
+                      onClick={() => toggleActionMenu(dish.id)}
+                      aria-label={`Действия с блюдом ${dish.name}`}
                     >
-                      Удалить
+                      ⚙️
                     </Button>
+                    {openActionMenuId === dish.id && (
+                      <div className="dish-card__menu" role="menu">
+                        <button
+                          type="button"
+                          className="dish-card__menu-item"
+                          onClick={() => {
+                            closeActionMenu();
+                            openEditDishModal(dish);
+                          }}
+                        >
+                          Редактировать
+                        </button>
+                        <button
+                          type="button"
+                          className="dish-card__menu-item dish-card__menu-item--danger"
+                          onClick={() => {
+                            closeActionMenu();
+                            deleteDish(dish.id);
+                          }}
+                          disabled={isMutating}
+                        >
+                          Удалить
+                        </button>
+                      </div>
+                    )}
                   </div>
                 }
               />
 
               <CardContent>
                 <div className="dish-card__info">
-                  {dish.instructions ? (
-                    <p className="multiline">{dish.instructions}</p>
+                  {dish.description ? (
+                    <p className="multiline">{dish.description}</p>
                   ) : (
-                    <p className="muted">Нет инструкций по приготовлению</p>
+                    <p className="muted">Нет описания блюда</p>
                   )}
 
                   <div className="dish-card__meta">
@@ -384,9 +421,6 @@ export const DishesPage = ({
                 <div className="dish-card__ingredients">
                   <div className="section-header">
                     <h3>Ингредиенты</h3>
-                    <Button variant="ghost" onClick={() => openIngredientModal(dish)}>
-                      Добавить
-                    </Button>
                   </div>
                   {dish.products?.length ? (
                     <div className="ingredient-tag-list">


### PR DESCRIPTION
## Summary
- adjust dish cards to show descriptions in content, remove inline ingredient add button, and swap edit/delete for a settings menu
- add navigation from dish cards to a dedicated dish detail page with full information
- style new actions menu and detail layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505c4dd1888330b8d12eff7ff68fce)