### PR TITLE
Add search functionality to dishes page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,17 @@
   flex-wrap: wrap;
 }
 
+.page__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.page__filters .form-field__input {
+  min-width: clamp(240px, 40vw, 420px);
+}
+
 .page__title {
   margin: 0;
   font-size: 1.4rem;

--- a/src/App.css
+++ b/src/App.css
@@ -57,6 +57,59 @@
   font-size: 1.05rem;
 }
 
+.autocomplete {
+  position: relative;
+  display: grid;
+  gap: var(--space-3xs);
+}
+
+.autocomplete__list {
+  position: absolute;
+  top: calc(100% + var(--space-3xs));
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: var(--space-4xs);
+  max-height: 240px;
+  overflow-y: auto;
+  padding: var(--space-2xs);
+  margin: 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  z-index: 2;
+}
+
+.autocomplete__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-xs);
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.autocomplete__option:hover,
+.autocomplete__option:focus {
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.autocomplete__check {
+  color: var(--color-accent-strong);
+  font-weight: 700;
+}
+
+.autocomplete__empty {
+  padding: var(--space-xs);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.03);
+  color: var(--color-muted);
+}
+
 .section {
   display: grid;
   gap: var(--space-md);

--- a/src/App.css
+++ b/src/App.css
@@ -17,10 +17,12 @@
   align-items: center;
   gap: var(--space-sm);
   flex-wrap: wrap;
+  width: 100%;
 }
 
 .page__filters .form-field__input {
-  min-width: clamp(240px, 40vw, 420px);
+  flex: 1 1 100%;
+  min-width: 0;
 }
 
 .page__title {

--- a/src/pages/DishesPage.js
+++ b/src/pages/DishesPage.js
@@ -385,8 +385,13 @@ export const DishesPage = ({
             aria-label="Поиск по блюдам"
           />
           {searchQuery && (
-            <Button variant="ghost" onClick={() => setSearchQuery('')}>
-              Очистить
+            <Button
+              variant="ghost"
+              className="icon-button"
+              onClick={() => setSearchQuery('')}
+              aria-label="Очистить поиск"
+            >
+              ×
             </Button>
           )}
         </div>

--- a/src/pages/DishesPage.js
+++ b/src/pages/DishesPage.js
@@ -384,16 +384,6 @@ export const DishesPage = ({
             placeholder="Поиск по названию или описанию"
             aria-label="Поиск по блюдам"
           />
-          {searchQuery && (
-            <Button
-              variant="ghost"
-              className="icon-button"
-              onClick={() => setSearchQuery('')}
-              aria-label="Очистить поиск"
-            >
-              ×
-            </Button>
-          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add a search field to filter dishes by name or description
- handle empty search results with a clear action while keeping existing empty state
- style the page-level filters for the new search controls

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695158816fa48330bf3f75a4f75ab965)