### PR TITLE
Shorten meal groups heading and button on narrow screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,14 +31,20 @@
   color: var(--color-text-strong);
 }
 
-.meal-groups__add-button {
+.meal-groups__add-button,
+.meal-group__add-button {
   gap: var(--space-3xs);
 }
 
-.meal-groups__add-icon {
+.meal-groups__add-icon,
+.meal-group__add-icon {
   display: none;
   font-size: 1.1rem;
   line-height: 1;
+}
+
+.meal-group__add-label {
+  display: inline;
 }
 
 .grid {
@@ -569,16 +575,19 @@
 }
 
 @media (max-width: 540px) {
-  .meal-groups__add-button {
+  .meal-groups__add-button,
+  .meal-group__add-button {
     padding: var(--space-2xs) var(--space-sm);
     min-width: auto;
   }
 
-  .meal-groups__add-label {
+  .meal-groups__add-label,
+  .meal-group__add-label {
     display: none;
   }
 
-  .meal-groups__add-icon {
+  .meal-groups__add-icon,
+  .meal-group__add-icon {
     display: inline;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,16 @@
   color: var(--color-text-strong);
 }
 
+.meal-groups__add-button {
+  gap: var(--space-3xs);
+}
+
+.meal-groups__add-icon {
+  display: none;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
 .grid {
   display: grid;
   gap: var(--space-lg);
@@ -555,6 +565,21 @@
 @media (min-width: 768px) {
   .page__title {
     font-size: 1.6rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .meal-groups__add-button {
+    padding: var(--space-2xs) var(--space-sm);
+    min-width: auto;
+  }
+
+  .meal-groups__add-label {
+    display: none;
+  }
+
+  .meal-groups__add-icon {
+    display: inline;
   }
 }
 

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -76,7 +76,14 @@ export const MealGroupDetailPage = ({
           {mealGroup.description && <p className="muted">{mealGroup.description}</p>}
         </div>
 
-        <Button onClick={openAssignDishModal}>Добавить блюдо</Button>
+        <Button
+          onClick={openAssignDishModal}
+          className="meal-group__add-button"
+          aria-label="Добавить блюдо"
+        >
+          <span className="meal-group__add-label">Добавить блюдо</span>
+          <span className="meal-group__add-icon" aria-hidden>+</span>
+        </Button>
       </div>
 
       <div className="section">
@@ -137,7 +144,16 @@ export const MealGroupDetailPage = ({
           <EmptyState
             title="Блюд пока нет"
             description="Добавьте первые блюда в этот набор, чтобы перейти к планированию."
-            action={<Button onClick={openAssignDishModal}>Добавить блюдо</Button>}
+            action={(
+              <Button
+                onClick={openAssignDishModal}
+                className="meal-group__add-button"
+                aria-label="Добавить блюдо"
+              >
+                <span className="meal-group__add-label">Добавить блюдо</span>
+                <span className="meal-group__add-icon" aria-hidden>+</span>
+              </Button>
+            )}
           />
         )}
       </div>

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -37,6 +37,13 @@ export const MealGroupDetailPage = ({
     return availableDishOptions.filter((option) => option.label.toLowerCase().includes(query));
   }, [availableDishOptions, searchTerm]);
 
+  const description = useMemo(() => {
+    if (!mealGroup?.description) return null;
+
+    const normalized = mealGroup.description.trim();
+    return normalized.length > 60 ? `${normalized.slice(0, 57)}…` : normalized;
+  }, [mealGroup?.description]);
+
   const openAssignDishModal = () => {
     setSelectedDishId('');
     setSearchTerm('');
@@ -66,13 +73,6 @@ export const MealGroupDetailPage = ({
       />
     );
   }
-
-  const description = useMemo(() => {
-    if (!mealGroup?.description) return null;
-
-    const normalized = mealGroup.description.trim();
-    return normalized.length > 60 ? `${normalized.slice(0, 57)}…` : normalized;
-  }, [mealGroup?.description]);
 
   return (
     <div className="page">

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -67,13 +67,20 @@ export const MealGroupDetailPage = ({
     );
   }
 
+  const description = useMemo(() => {
+    if (!mealGroup?.description) return null;
+
+    const normalized = mealGroup.description.trim();
+    return normalized.length > 60 ? `${normalized.slice(0, 57)}…` : normalized;
+  }, [mealGroup?.description]);
+
   return (
     <div className="page">
       <div className="page__header">
         <div className="page__breadcrumbs">
           <button type="button" className="link-button" onClick={onBack}>← Назад к наборам</button>
           <h2 className="page__title">{mealGroup.name}</h2>
-          {mealGroup.description && <p className="muted">{mealGroup.description}</p>}
+          {description && <p className="muted">{description}</p>}
         </div>
 
         <Button

--- a/src/pages/MealPlannerPage.js
+++ b/src/pages/MealPlannerPage.js
@@ -80,7 +80,7 @@ export const MealPlannerPage = ({
   return (
     <div className="page">
       <div className="page__header">
-        <h2 className="page__title">Наборы</h2>
+        <h2 className="page__title">Наборы приёмов пищи</h2>
         <Button onClick={openCreateModal} className="meal-groups__add-button" aria-label="Новый набор">
           <span className="meal-groups__add-label">Новый набор</span>
           <span className="meal-groups__add-icon" aria-hidden>

--- a/src/pages/MealPlannerPage.js
+++ b/src/pages/MealPlannerPage.js
@@ -80,8 +80,13 @@ export const MealPlannerPage = ({
   return (
     <div className="page">
       <div className="page__header">
-        <h2 className="page__title">Наборы приёмов пищи</h2>
-        <Button onClick={openCreateModal}>Новый набор</Button>
+        <h2 className="page__title">Наборы</h2>
+        <Button onClick={openCreateModal} className="meal-groups__add-button" aria-label="Новый набор">
+          <span className="meal-groups__add-label">Новый набор</span>
+          <span className="meal-groups__add-icon" aria-hidden>
+            +
+          </span>
+        </Button>
       </div>
 
       {mealGroups.length === 0 ? (


### PR DESCRIPTION
## Summary
- shorten the meal group section heading to a concise label
- make the add meal group button responsive with an icon-only appearance on narrow screens to keep the header on one line

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954284fccf0833095e6a4ef99897b62)