### PR TITLE
Keep card header actions aligned

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,25 @@
   flex-wrap: wrap;
 }
 
+.page__header--aligned {
+  align-items: flex-start;
+  flex-wrap: nowrap;
+}
+
+.page__header--aligned .page__breadcrumbs {
+  min-width: 0;
+  flex: 1;
+}
+
+.page__header--aligned .page__title,
+.page__header--aligned .muted {
+  word-break: break-word;
+}
+
+.page__header--aligned .dish-card__actions {
+  flex-shrink: 0;
+}
+
 .page__filters {
   display: flex;
   align-items: center;

--- a/src/components/common/Card.css
+++ b/src/components/common/Card.css
@@ -46,12 +46,15 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-md);
+  flex-wrap: nowrap;
 }
 
 .card__title-group {
   display: flex;
   gap: var(--space-sm);
   align-items: center;
+  flex: 1;
+  min-width: 0;
 }
 
 .card__accent {
@@ -78,6 +81,8 @@
 .card__header-actions {
   display: flex;
   gap: var(--space-xs);
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .card__content {

--- a/src/pages/DishDetailPage.js
+++ b/src/pages/DishDetailPage.js
@@ -29,7 +29,7 @@ export const DishDetailPage = ({ dish, onBack, onEditDish, onDeleteDish, isMutat
 
   return (
     <div className="page">
-      <div className="page__header">
+      <div className="page__header page__header--aligned">
         <div className="page__breadcrumbs">
           <button type="button" className="link-button" onClick={onBack}>
             ← Назад к блюдам


### PR DESCRIPTION
## Summary
- prevent card headers from wrapping controls below the title
- allow title and subtitle to share space while keeping action buttons aligned to the right

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542e9a458c83308a77e9d21b7a8985)