### PR TITLE
Use relative /api base URL and add Vercel rewrites

### DIFF
--- a/src/api/apiConfig.js
+++ b/src/api/apiConfig.js
@@ -1,13 +1,13 @@
-const DEFAULT_BASE_URL = 'https://localhost:7252';
+const DEFAULT_BASE_URL = '/api';
 
 export const apiConfig = {
   baseUrl: process.env.REACT_APP_API_BASE_URL || DEFAULT_BASE_URL,
   endpoints: {
-    dishes: '/api/dishes',
-    products: '/api/products',
-    mealGroups: '/api/meal-groups',
-    dishProducts: '/api/dish-products',
-    mealGroupDishes: '/api/meal-group-dishes',
+    dishes: '/dishes',
+    products: '/products',
+    mealGroups: '/meal-groups',
+    dishProducts: '/dish-products',
+    mealGroupDishes: '/meal-group-dishes',
   },
 };
 
@@ -17,4 +17,3 @@ export const buildApiUrl = (path = '') => {
 };
 
 export const getEndpoint = (key) => apiConfig.endpoints[key];
-

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "http://YOUR_VPS_IP:8080/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Remove hardcoded localhost/IP usage in the client so API requests go through the same origin and can be proxied in production.
- Provide a deployment-time proxy and SPA fallback so the frontend can be hosted on Vercel while the API runs on a VPS.

### Description
- Set `DEFAULT_BASE_URL` to `'/api'` and preserve override via `REACT_APP_API_BASE_URL` so the client uses a relative API base by default.
- Updated endpoint paths to remove the duplicate `/api` prefix so `buildApiUrl` produces URLs like `/api/dishes` (e.g. endpoints are `'/dishes'`, `'/products'`).
- Added `vercel.json` with rewrites that proxy `"/api/(.*)"` to `"http://YOUR_VPS_IP:8080/$1"` and route all other requests to `/index.html` for SPA fallback.

### Testing
- Ran `npm run build` and the production build completed successfully (build succeeded with unrelated ESLint warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b84fe8ed4833088caeb35391c2cee)