### PR TITLE
Fix React hook dependency lint warnings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -165,7 +165,7 @@ function App() {
           />
         );
     }
-  }, [activeDish, activeGroup, dishDetailReturnView, planner, view]);
+  }, [activeDish, activeGroup, dishDetailReturnView, pendingDishEditId, planner, view]);
 
   return (
     <AppLayout
@@ -190,4 +190,3 @@ function App() {
 }
 
 export default App;
-

--- a/src/pages/DishesPage.js
+++ b/src/pages/DishesPage.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader } from '../components/common/Card';
 import { Button } from '../components/common/Button';
 import { Modal } from '../components/common/Modal';
@@ -87,6 +87,22 @@ export const DishesPage = ({
     return map;
   }, [mealGroups]);
 
+  const openEditDishModal = useCallback((dish) => {
+    setEditingDish(dish);
+    setDishForm({
+      name: dish.name ?? '',
+      description: dish.description ?? '',
+      instructions: dish.instructions ?? '',
+      preparationMinutes: dish.preparationMinutes ?? '',
+      imageUrl: dish.imageUrl ?? '',
+    });
+    setDishErrors({});
+    setPendingIngredients([]);
+    setSelectedGroupIds([...(dishGroupMap.get(dish.id) ?? [])]);
+    setGroupSelectValue('');
+    setDishModalOpen(true);
+  }, [dishGroupMap]);
+
   useEffect(() => {
     if (!editingDishId) {
       return;
@@ -101,7 +117,7 @@ export const DishesPage = ({
 
     openEditDishModal(dishToEdit);
     onEditingDishHandled?.();
-  }, [dishes, editingDishId, onEditingDishHandled]);
+  }, [dishes, editingDishId, onEditingDishHandled, openEditDishModal]);
 
   useEffect(() => {
     if (!editingDish) {
@@ -120,22 +136,6 @@ export const DishesPage = ({
     setDishErrors({});
     setPendingIngredients([]);
     setSelectedGroupIds([]);
-    setGroupSelectValue('');
-    setDishModalOpen(true);
-  };
-
-  const openEditDishModal = (dish) => {
-    setEditingDish(dish);
-    setDishForm({
-      name: dish.name ?? '',
-      description: dish.description ?? '',
-      instructions: dish.instructions ?? '',
-      preparationMinutes: dish.preparationMinutes ?? '',
-      imageUrl: dish.imageUrl ?? '',
-    });
-    setDishErrors({});
-    setPendingIngredients([]);
-    setSelectedGroupIds([...(dishGroupMap.get(dish.id) ?? [])]);
     setGroupSelectValue('');
     setDishModalOpen(true);
   };
@@ -795,4 +795,3 @@ export const DishesPage = ({
     </div>
   );
 };
-

--- a/src/pages/MealGroupDetailPage.js
+++ b/src/pages/MealGroupDetailPage.js
@@ -24,7 +24,10 @@ export const MealGroupDetailPage = ({
     [dishes],
   );
 
-  const selectedGroupDishIds = mealGroup?.dishes?.map((item) => item.dishId) ?? [];
+  const selectedGroupDishIds = useMemo(
+    () => mealGroup?.dishes?.map((item) => item.dishId) ?? [],
+    [mealGroup?.dishes],
+  );
   const availableDishOptions = useMemo(
     () => dishOptions.filter((option) => !selectedGroupDishIds.includes(Number(option.value))),
     [dishOptions, selectedGroupDishIds],


### PR DESCRIPTION
### Motivation

- Устранить предупреждения ESLint о пропущенных зависимостях хуков `useMemo`/`useEffect` в страницах приложения.
- Сделать зависимости стабильными, чтобы избежать некорректных повторных вызовов эффектов и пересчётов мемоизированных значений.

### Description

- Добавил `pendingDishEditId` в массив зависимостей `useMemo` для `content` в `src/App.js` чтобы включить используемое внутри значение в deps (`pendingDishEditId`).
- В `src/pages/DishesPage.js` импортировал `useCallback`, обернул `openEditDishModal` в `useCallback` с зависимостью `dishGroupMap` и добавил `openEditDishModal` в зависимости соответствующего `useEffect` чтобы устранить зависимость от нестабильной функции.
- В `src/pages/MealGroupDetailPage.js` вычисление `selectedGroupDishIds` переместил в отдельный `useMemo` с зависимостью на `mealGroup?.dishes`, чтобы downstream `useMemo`/`useEffect` смотрели на стабильную ссылку.

### Testing

- Запущена сборка проекта с помощью `npm run build`, сборка завершилась успешно and produced an optimized production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b875ec3a0833090f1bfe3a5c76520)